### PR TITLE
chore: align crate lib names, bump versions, and fix Moon treefmt PATH

### DIFF
--- a/crates/id_effect_axum/Cargo.toml
+++ b/crates/id_effect_axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "id_effect_axum"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "CC-BY-SA-4.0"
 description = "Axum integration for the workspace `effect` crate — run Effect handlers on Tokio"
@@ -14,13 +14,13 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [lib]
-name = "effect_axum"
+name = "id_effect_axum"
 
 [dependencies]
 id_effect = { path = "../id_effect", version = "0.1.0", features = [
   "schema-serde",
 ] }
-id_effect_tokio = { path = "../id_effect_tokio", version = "0.1.0" }
+id_effect_tokio = { path = "../id_effect_tokio", version = "0.1.1" }
 axum = { version = "0.7" }
 http-body-util = "0.1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/id_effect_axum/examples/010_routing_hello.rs
+++ b/crates/id_effect_axum/examples/010_routing_hello.rs
@@ -1,14 +1,14 @@
-//! Minimal [`Router`] + [`effect_axum::routing::get`]: state → `Effect` → HTTP response.
+//! Minimal [`Router`] + [`id_effect_axum::routing::get`]: state → `Effect` → HTTP response.
 //!
 //! Run: `cargo run -p id_effect_axum --example 010_routing_hello`
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use axum::routing::Router;
-use effect_axum::routing;
 use http_body_util::BodyExt;
 use id_effect::Effect;
 use id_effect::succeed;
+use id_effect_axum::routing;
 use std::convert::Infallible;
 use tower::ServiceExt;
 

--- a/crates/id_effect_axum/examples/020_async_effect.rs
+++ b/crates/id_effect_axum/examples/020_async_effect.rs
@@ -1,13 +1,13 @@
-//! `Effect::new_async` with `tokio::time::sleep` under [`effect_tokio::run_async`] (via routing).
+//! `Effect::new_async` with `tokio::time::sleep` under [`id_effect_tokio::run_async`] (via routing).
 //!
 //! Run: `cargo run -p id_effect_axum --example 020_async_effect`
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use axum::routing::Router;
-use effect_axum::routing;
 use http_body_util::BodyExt;
 use id_effect::Effect;
+use id_effect_axum::routing;
 use std::convert::Infallible;
 use std::time::Duration;
 use tower::ServiceExt;

--- a/crates/id_effect_axum/examples/030_execute_handler.rs
+++ b/crates/id_effect_axum/examples/030_execute_handler.rs
@@ -1,4 +1,4 @@
-//! Use [`effect_axum::execute`] when the handler is already an `async` closure and you want to
+//! Use [`id_effect_axum::execute`] when the handler is already an `async` closure and you want to
 //! compose extra Axum extractors or middleware around [`State`].
 //!
 //! Run: `cargo run -p id_effect_axum --example 030_execute_handler`
@@ -7,9 +7,9 @@ use axum::body::Body;
 use axum::extract::State;
 use axum::http::{Request, StatusCode};
 use axum::routing::Router;
-use effect_axum::execute;
 use http_body_util::BodyExt;
 use id_effect::succeed;
+use id_effect_axum::execute;
 use std::convert::Infallible;
 use tower::ServiceExt;
 

--- a/crates/id_effect_axum/src/lib.rs
+++ b/crates/id_effect_axum/src/lib.rs
@@ -7,7 +7,7 @@
 //! - Your domain stays in `Effect<A, E, R>` with environment `R` (often clone-cheap state with
 //!   `Arc` fields, or a [`id_effect::Context`] stack).
 //! - This crate **bridges** `State<R>` → `&mut R` for one build step, then runs the effect with
-//!   [`effect_tokio::run_async`] so pending effect steps compose with Tokio I/O.
+//!   [`id_effect_tokio::run_async`] so pending effect steps compose with Tokio I/O.
 //!
 //! ## Runtime requirements
 //!
@@ -23,7 +23,7 @@
 //!
 //! **Yes — this crate is built on `id_effect_tokio`** (workspace crate `crates/id_effect_tokio`).
 //! [`crate::routing`] and [`run_with_env`]/[`execute`] all drive effects via
-//! [`effect_tokio::run_async`], so async steps inside `Effect` run on the **same** Tokio runtime as
+//! [`id_effect_tokio::run_async`], so async steps inside `Effect` run on the **same** Tokio runtime as
 //! `#[tokio::main]` / `axum::serve`.
 //!
 //! ## Quick start
@@ -31,7 +31,7 @@
 //! ```ignore
 //! use axum::{Router, extract::State};
 //! use id_effect::{succeed, Effect};
-//! use effect_axum::routing;
+//! use id_effect_axum::routing;
 //!
 //! #[derive(Clone)]
 //! struct AppState { /* … */ }
@@ -74,8 +74,8 @@ pub use channel_bridge::{exchange, exchange_into_response};
 
 use axum::extract::State;
 use axum::response::{IntoResponse, Response};
-use effect_tokio::run_async;
 use id_effect::Effect;
+use id_effect_tokio::run_async;
 
 /// Run `build(&mut env)` to obtain an effect, then drive it to completion with the **same** `env`.
 ///

--- a/crates/id_effect_config/Cargo.toml
+++ b/crates/id_effect_config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "id_effect_config"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "CC-BY-SA-4.0"
 description = "Effect.ts-style ConfigProvider + Figment/serde layers for the workspace `effect` crate"
@@ -27,11 +27,11 @@ yaml = ["figment/yaml"]
 dotenv = ["dep:dotenvy"]
 
 [lib]
-name = "effect_config"
+name = "id_effect_config"
 
 [dependencies]
 id_effect = { path = "../id_effect", version = "0.1.0" }
-id_effect_logger = { path = "../id_effect_logger", version = "0.1.0" }
+id_effect_logger = { path = "../id_effect_logger", version = "0.1.1" }
 # Floor for figment's pear dep: 0.2.0 does not build on current Rust (fmt::Write on InlinableString).
 pear = "0.2.9"
 figment = { version = "0.10.19", default-features = false }

--- a/crates/id_effect_config/examples/001_extract_toml.rs
+++ b/crates/id_effect_config/examples/001_extract_toml.rs
@@ -1,6 +1,6 @@
-//! Deserialize a struct from a TOML file with Figment and [`effect_config::extract`].
+//! Deserialize a struct from a TOML file with Figment and [`id_effect_config::extract`].
 
-use effect_config::{extract, figment};
+use id_effect_config::{extract, figment};
 use serde::Deserialize;
 use std::io::Write;
 

--- a/crates/id_effect_config/examples/002_map_provider.rs
+++ b/crates/id_effect_config/examples/002_map_provider.rs
@@ -1,9 +1,9 @@
-//! [`MapConfigProvider`] with [`effect_config::config`] helpers (nested keys, defaults).
+//! [`MapConfigProvider`] with [`id_effect_config::config`] helpers (nested keys, defaults).
 
-use effect_config::MapConfigProvider;
-use effect_config::config;
+use id_effect_config::MapConfigProvider;
+use id_effect_config::config;
 
-fn main() -> Result<(), effect_config::ConfigError> {
+fn main() -> Result<(), id_effect_config::ConfigError> {
   let p = MapConfigProvider::from_pairs([("SERVICE_HOST", "localhost"), ("SERVICE_NAME", "demo")]);
 
   let host = config::nested_string(&p, "SERVICE", "HOST")?;

--- a/crates/id_effect_config/examples/003_figment_provider_layer.rs
+++ b/crates/id_effect_config/examples/003_figment_provider_layer.rs
@@ -1,8 +1,8 @@
-//! Build a [`FigmentConfigProvider`](effect_config::FigmentConfigProvider) via
-//! [`FigmentProviderLayer`](effect_config::FigmentProviderLayer) and [`id_effect::Layer`].
+//! Build a [`FigmentConfigProvider`](id_effect_config::FigmentConfigProvider) via
+//! [`FigmentProviderLayer`](id_effect_config::FigmentProviderLayer) and [`id_effect::Layer`].
 
-use effect_config::{FigmentProviderLayer, config, figment};
 use id_effect::Layer;
+use id_effect_config::{FigmentProviderLayer, config, figment};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
   let dir = tempfile::tempdir()?;

--- a/crates/id_effect_config/examples/004_or_else_provider.rs
+++ b/crates/id_effect_config/examples/004_or_else_provider.rs
@@ -1,10 +1,10 @@
-//! [`OrElseConfigProvider`](effect_config::OrElseConfigProvider): try one source, then another.
+//! [`OrElseConfigProvider`](id_effect_config::OrElseConfigProvider): try one source, then another.
 
-use effect_config::config;
-use effect_config::{MapConfigProvider, OrElseConfigProvider};
+use id_effect_config::config;
+use id_effect_config::{MapConfigProvider, OrElseConfigProvider};
 use std::collections::HashMap;
 
-fn main() -> Result<(), effect_config::ConfigError> {
+fn main() -> Result<(), id_effect_config::ConfigError> {
   let primary = MapConfigProvider::from_map(HashMap::new());
   let backup = MapConfigProvider::from_pairs([("API_KEY", "fallback-key")]);
   let p = OrElseConfigProvider::new(primary, backup);

--- a/crates/id_effect_config/src/config_desc.rs
+++ b/crates/id_effect_config/src/config_desc.rs
@@ -14,7 +14,7 @@
 //!
 //! ```rust
 //! use std::sync::Arc;
-//! use effect_config::{Config, MapConfigProvider, config_env, ConfigError};
+//! use id_effect_config::{Config, MapConfigProvider, config_env, ConfigError};
 //! use id_effect::run_blocking;
 //!
 //! let p = MapConfigProvider::from_pairs([
@@ -43,8 +43,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use ::id_effect::{Effect, Get, Here, effect};
-use effect_logger::LogLevel;
 use id_effect::duration::duration;
+use id_effect_logger::LogLevel;
 use url::Url;
 
 use crate::ambient::current_config_provider;
@@ -152,7 +152,7 @@ impl<T: Send + Sync + 'static> Config<T> {
   /// Transform the loaded value (Effect `Config.map`).
   ///
   /// ```rust
-  /// use effect_config::{Config, MapConfigProvider};
+  /// use id_effect_config::{Config, MapConfigProvider};
   ///
   /// let p = MapConfigProvider::from_pairs([("PORT", "8080")]);
   /// let port_u16: u16 = Config::integer("PORT").map(|n| n as u16).load(&p).unwrap();
@@ -190,7 +190,7 @@ impl<T: Send + Sync + 'static> Config<T> {
   /// Wrap the loaded value in [`Secret`] so it is never printed (Effect `Config.secret`).
   ///
   /// ```rust
-  /// use effect_config::{Config, MapConfigProvider};
+  /// use id_effect_config::{Config, MapConfigProvider};
   ///
   /// let p = MapConfigProvider::from_pairs([("API_KEY", "s3cr3t")]);
   /// let key = Config::string("API_KEY").secret().load(&p).unwrap();
@@ -209,7 +209,7 @@ impl<T: Send + Sync + 'static> Config<T> {
   /// `Config::string("PORT").nested("SERVER")` looks up `["SERVER", "PORT"]`.
   ///
   /// ```rust
-  /// use effect_config::{Config, MapConfigProvider};
+  /// use id_effect_config::{Config, MapConfigProvider};
   ///
   /// let p = MapConfigProvider::from_pairs([("SERVER_HOST", "127.0.0.1")]);
   /// let host = Config::string("HOST").nested("SERVER").load(&p).unwrap();
@@ -245,7 +245,7 @@ impl<T: Clone + Send + Sync + 'static> Config<T> {
   /// Only [`ConfigError::Missing`] triggers the fallback; parse errors still propagate.
   ///
   /// ```rust
-  /// use effect_config::{Config, MapConfigProvider};
+  /// use id_effect_config::{Config, MapConfigProvider};
   ///
   /// let p = MapConfigProvider::from_pairs::<[(&str, &str); 0], _, _>([]);
   /// let port = Config::integer("PORT").with_default(3000).load(&p).unwrap();
@@ -265,7 +265,7 @@ impl<T: Clone + Send + Sync + 'static> Config<T> {
   /// Validate the loaded value; produces `ConfigError::Invalid` when `predicate` is false.
   ///
   /// ```rust
-  /// use effect_config::{Config, MapConfigProvider};
+  /// use id_effect_config::{Config, MapConfigProvider};
   ///
   /// let p = MapConfigProvider::from_pairs([("PORT", "99999")]);
   /// let err = Config::integer("PORT")
@@ -464,7 +464,7 @@ impl Config<Duration> {
   ///
   /// ```rust
   /// use std::time::Duration;
-  /// use effect_config::{Config, MapConfigProvider};
+  /// use id_effect_config::{Config, MapConfigProvider};
   ///
   /// let p = MapConfigProvider::from_pairs([("TIMEOUT", "5s")]);
   /// let t = Config::duration("TIMEOUT").load(&p).unwrap();
@@ -493,7 +493,7 @@ impl Config<Duration> {
 }
 
 impl Config<LogLevel> {
-  /// Load a [`LogLevel`] (case-insensitive; see [`LogLevel`](effect_logger::LogLevel)).
+  /// Load a [`LogLevel`] (case-insensitive; see [`LogLevel`](id_effect_logger::LogLevel)).
   pub fn log_level(path: impl Into<String>) -> Self {
     let segs = split_dotted(&path.into());
     Self::new(move |p| {
@@ -547,7 +547,7 @@ impl Config<Url> {
 /// Both are loaded; the first error encountered is returned.
 ///
 /// ```rust
-/// use effect_config::{config, Config, MapConfigProvider};
+/// use id_effect_config::{config, Config, MapConfigProvider};
 ///
 /// let p = MapConfigProvider::from_pairs([("HOST", "0.0.0.0"), ("PORT", "9000")]);
 /// let (host, port) = config::all(Config::string("HOST"), Config::integer("PORT"))
@@ -640,7 +640,7 @@ mod tests {
   use std::time::Duration;
 
   use crate::MapConfigProvider;
-  use effect_logger::LogLevel;
+  use id_effect_logger::LogLevel;
 
   use super::*;
 

--- a/crates/id_effect_config/src/lib.rs
+++ b/crates/id_effect_config/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! ```rust
 //! use std::sync::Arc;
-//! use effect_config::{Config, MapConfigProvider, config_env, config, ConfigError};
+//! use id_effect_config::{Config, MapConfigProvider, config_env, config, ConfigError};
 //! use id_effect::run_blocking;
 //!
 //! let p = MapConfigProvider::from_pairs([("HOST", "localhost"), ("PORT", "8080")]);
@@ -40,7 +40,7 @@
 //! Inject the provider via the effect environment and call the free functions directly:
 //!
 //! ```ignore
-//! use effect_config::{read_string, NeedsConfigProvider, ConfigError};
+//! use id_effect_config::{read_string, NeedsConfigProvider, ConfigError};
 //!
 //! fn load_host<A, E, R>() -> ::id_effect::Effect<A, E, R>
 //! where
@@ -95,7 +95,7 @@ pub type ConfigEnv = ::id_effect::Context<
 ///
 /// ```rust
 /// use std::sync::Arc;
-/// use effect_config::{Config, MapConfigProvider, config_env, ConfigError};
+/// use id_effect_config::{Config, MapConfigProvider, config_env, ConfigError};
 /// use id_effect::run_blocking;
 ///
 /// let p = MapConfigProvider::from_pairs([("HOST", "localhost")]);

--- a/crates/id_effect_config/src/provider.rs
+++ b/crates/id_effect_config/src/provider.rs
@@ -85,7 +85,7 @@ pub trait ConfigProvider: Send + Sync {
   /// (Effect `ConfigProvider.within`).
   ///
   /// ```rust
-  /// use effect_config::{ConfigProvider, MapConfigProvider};
+  /// use id_effect_config::{ConfigProvider, MapConfigProvider};
   ///
   /// let base = MapConfigProvider::from_pairs([("SERVER_HOST", "localhost")]);
   /// let scoped = base.within("SERVER");
@@ -329,7 +329,7 @@ impl<A: ConfigProvider + Clone + 'static, B: ConfigProvider + Clone + 'static> C
 /// Created via [`ConfigProvider::within`].
 ///
 /// ```rust
-/// use effect_config::{ConfigProvider, MapConfigProvider, config};
+/// use id_effect_config::{ConfigProvider, MapConfigProvider, config};
 ///
 /// let base = MapConfigProvider::from_pairs([("DB_HOST", "localhost"), ("DB_PORT", "5432")]);
 /// let db = base.within("DB");

--- a/crates/id_effect_config/src/secret.rs
+++ b/crates/id_effect_config/src/secret.rs
@@ -7,7 +7,7 @@ use std::fmt;
 /// Mirrors Effect.ts `Config.secret` / `ConfigSecret`.
 ///
 /// ```rust
-/// use effect_config::Secret;
+/// use id_effect_config::Secret;
 ///
 /// let token = Secret::new("my-api-key".to_string());
 /// assert_eq!(format!("{token:?}"), "<redacted>");

--- a/crates/id_effect_logger/Cargo.toml
+++ b/crates/id_effect_logger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "id_effect_logger"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "CC-BY-SA-4.0"
 description = "Effect-logging service (forwards to tracing) for effect! / AsyncEffect programs"
@@ -14,7 +14,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [lib]
-name = "effect_logger"
+name = "id_effect_logger"
 
 [dependencies]
 id_effect = { path = "../id_effect", version = "0.1.0" }

--- a/crates/id_effect_logger/examples/context_service.rs
+++ b/crates/id_effect_logger/examples/context_service.rs
@@ -4,7 +4,7 @@
 //! Run: `devenv shell -- cargo run -p logger --example context_service`
 
 use ::id_effect::{Cons, Context, Effect, Nil, Service, effect, run_blocking};
-use effect_logger::{EffectLogKey, EffectLogger, EffectLoggerError};
+use id_effect_logger::{EffectLogKey, EffectLogger, EffectLoggerError};
 
 type LogR = Context<Cons<Service<EffectLogKey, EffectLogger>, Nil>>;
 

--- a/crates/id_effect_logger/examples/effect_logger.rs
+++ b/crates/id_effect_logger/examples/effect_logger.rs
@@ -5,7 +5,7 @@
 //! Run: `RUST_LOG=debug devenv shell -- cargo run -p logger --example effect_logger`
 
 use ::id_effect::run_blocking;
-use effect_logger::{EffectLogger, LogLevel};
+use id_effect_logger::{EffectLogger, LogLevel};
 
 fn main() {
   tracing_subscriber::fmt()

--- a/crates/id_effect_logger/examples/layer_build.rs
+++ b/crates/id_effect_logger/examples/layer_build.rs
@@ -1,11 +1,11 @@
-//! Build the logger layer with [`effect_logger::layer_effect_logger`]
+//! Build the logger layer with [`id_effect_logger::layer_effect_logger`]
 //! ([`id_effect::layer_service`] / Effect.ts `Layer.succeed`), then assemble a
 //! [`Context`] and run an effect that extracts `EffectLogger` via `~EffectLogger`.
 //!
 //! Run: `devenv shell -- cargo run -p logger --example layer_build`
 
 use ::id_effect::{Cons, Context, Effect, Layer, Nil, Service, effect, run_blocking};
-use effect_logger::{EffectLogKey, EffectLogger, EffectLoggerError, layer_effect_logger};
+use id_effect_logger::{EffectLogKey, EffectLogger, EffectLoggerError, layer_effect_logger};
 
 type LogEnv = Context<Cons<Service<EffectLogKey, EffectLogger>, Nil>>;
 

--- a/crates/id_effect_logger/examples/log_effects.rs
+++ b/crates/id_effect_logger/examples/log_effects.rs
@@ -4,7 +4,7 @@
 //! Run: `RUST_LOG=trace devenv shell -- cargo run -p logger --example log_effects`
 
 use ::id_effect::{Cons, Context, Effect, Nil, Service, effect, run_blocking};
-use effect_logger::{EffectLogKey, EffectLogger, EffectLoggerError};
+use id_effect_logger::{EffectLogKey, EffectLogger, EffectLoggerError};
 
 type LogCtx = Context<Cons<Service<EffectLogKey, EffectLogger>, Nil>>;
 

--- a/crates/id_effect_logger/examples/macro_block_tail.rs
+++ b/crates/id_effect_logger/examples/macro_block_tail.rs
@@ -5,7 +5,7 @@
 //! Run: `devenv shell -- cargo run -p logger --example macro_block_tail`
 
 use ::id_effect::{Cons, Context, Effect, Nil, Service, effect, run_blocking, succeed};
-use effect_logger::{EffectLogKey, EffectLogger, EffectLoggerError};
+use id_effect_logger::{EffectLogKey, EffectLogger, EffectLoggerError};
 
 type LogCtx = Context<Cons<Service<EffectLogKey, EffectLogger>, Nil>>;
 

--- a/crates/id_effect_logger/examples/macro_sync_bind.rs
+++ b/crates/id_effect_logger/examples/macro_sync_bind.rs
@@ -4,7 +4,7 @@
 //! Run: `devenv shell -- cargo run -p logger --example macro_sync_bind`
 
 use ::id_effect::{Cons, Context, Effect, Nil, Service, effect, run_blocking, succeed};
-use effect_logger::{EffectLogKey, EffectLogger, EffectLoggerError};
+use id_effect_logger::{EffectLogKey, EffectLogger, EffectLoggerError};
 
 type LogCtx = Context<Cons<Service<EffectLogKey, EffectLogger>, Nil>>;
 

--- a/crates/id_effect_reqwest/Cargo.toml
+++ b/crates/id_effect_reqwest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "id_effect_reqwest"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "CC-BY-SA-4.0"
 description = "reqwest integration for the workspace `effect` crate — HTTP as Effect programs"
@@ -14,7 +14,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [lib]
-name = "effect_reqwest"
+name = "id_effect_reqwest"
 
 [dependencies]
 bytes = "1"
@@ -32,6 +32,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [dev-dependencies]
-id_effect_tokio = { path = "../id_effect_tokio", version = "0.1.0" }
+id_effect_tokio = { path = "../id_effect_tokio", version = "0.1.1" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 wiremock = "0.6"

--- a/crates/id_effect_reqwest/examples/010_wiremock_get_text.rs
+++ b/crates/id_effect_reqwest/examples/010_wiremock_get_text.rs
@@ -1,11 +1,11 @@
-//! GET + [`effect_reqwest::text`] against a local [wiremock](https://docs.rs/wiremock) server, driven
-//! with [`effect_tokio::run_async`].
+//! GET + [`id_effect_reqwest::text`] against a local [wiremock](https://docs.rs/wiremock) server, driven
+//! with [`id_effect_tokio::run_async`].
 //!
 //! Run: `cargo run -p id_effect_reqwest --example 010_wiremock_get_text`
 
-use effect_reqwest::{Client, Error, ReqwestClientKey, text};
-use effect_tokio::run_async;
 use id_effect::service_env;
+use id_effect_reqwest::{Client, Error, ReqwestClientKey, text};
+use id_effect_tokio::run_async;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 

--- a/crates/id_effect_reqwest/examples/020_wiremock_json.rs
+++ b/crates/id_effect_reqwest/examples/020_wiremock_json.rs
@@ -1,10 +1,10 @@
-//! [`effect_reqwest::json`] with a typed response body.
+//! [`id_effect_reqwest::json`] with a typed response body.
 //!
 //! Run: `cargo run -p id_effect_reqwest --example 020_wiremock_json`
 
-use effect_reqwest::{Client, Error, ReqwestClientKey, json};
-use effect_tokio::run_async;
 use id_effect::service_env;
+use id_effect_reqwest::{Client, Error, ReqwestClientKey, json};
+use id_effect_tokio::run_async;
 use serde::{Deserialize, Serialize};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};

--- a/crates/id_effect_reqwest/examples/030_layer_default_env.rs
+++ b/crates/id_effect_reqwest/examples/030_layer_default_env.rs
@@ -1,12 +1,12 @@
-//! Build an [`effect_reqwest::Client`] with [`effect_reqwest::layer_reqwest_client_default`], wrap it in a
+//! Build an [`id_effect_reqwest::Client`] with [`id_effect_reqwest::layer_reqwest_client_default`], wrap it in a
 //! [`id_effect::Context`], and run an HTTP [`id_effect::Effect`].
 //!
 //! Run: `cargo run -p id_effect_reqwest --example 030_layer_default_env`
 
-use effect_reqwest::{Error, layer_reqwest_client_default, text};
-use effect_tokio::run_async;
 use id_effect::Layer;
 use id_effect::context::{Cons, Context, Nil};
+use id_effect_reqwest::{Error, layer_reqwest_client_default, text};
+use id_effect_tokio::run_async;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 

--- a/crates/id_effect_reqwest/src/lib.rs
+++ b/crates/id_effect_reqwest/src/lib.rs
@@ -14,13 +14,13 @@
 //! This crate depends only on **`effect`** (and `reqwest`). Async HTTP steps are ordinary
 //! [`Effect::new_async`](id_effect::Effect::new_async) bodies; drive them on Tokio with
 //! [`id_effect::run_async`] or the same symbol re-exported from **`id_effect_tokio`** as
-//! `effect_tokio::run_async` (recommended in Tokio services so sleep/yield stay consistent).
+//! `id_effect_tokio::run_async` (recommended in Tokio services so sleep/yield stay consistent).
 //!
 //! ## Example
 //!
 //! ```ignore
 //! use id_effect::{ctx, run_async, service, Context, Cons, Nil};
-//! use effect_reqwest::{ReqwestClientKey, send};
+//! use id_effect_reqwest::{ReqwestClientKey, send};
 //!
 //! type Env = Context<Cons<id_effect::Service<ReqwestClientKey, reqwest::Client>, Nil>>;
 //!

--- a/crates/id_effect_tokio/Cargo.toml
+++ b/crates/id_effect_tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "id_effect_tokio"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Tokio runtime adapter and re-exports for the workspace `effect` crate"
 license = "CC-BY-SA-4.0"
@@ -14,7 +14,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [lib]
-name = "effect_tokio"
+name = "id_effect_tokio"
 
 [dependencies]
 id_effect = { path = "../id_effect", version = "0.1.0" }

--- a/crates/id_effect_tokio/examples/106_tokio_runtime.rs
+++ b/crates/id_effect_tokio/examples/106_tokio_runtime.rs
@@ -2,8 +2,8 @@
 //!
 //! Run: `cargo run -p id_effect_tokio --example 106_tokio_runtime`
 
-use effect_tokio::{TokioRuntime, yield_now};
 use id_effect::{Runtime, run_async, succeed};
+use id_effect_tokio::{TokioRuntime, yield_now};
 use std::time::Duration;
 
 fn main() {

--- a/crates/id_effect_tokio/examples/107_tokio_fork_contract.rs
+++ b/crates/id_effect_tokio/examples/107_tokio_fork_contract.rs
@@ -2,9 +2,9 @@
 //!
 //! Run: `cargo run -p id_effect_tokio --example 107_tokio_fork_contract`
 
-use effect_tokio::TokioRuntime;
 use id_effect::kernel::succeed;
 use id_effect::run_fork;
+use id_effect_tokio::TokioRuntime;
 
 fn main() {
   let rt = TokioRuntime::new_current_thread().expect("tokio runtime should build");

--- a/crates/id_effect_tokio/examples/108_tokio_clock.rs
+++ b/crates/id_effect_tokio/examples/108_tokio_clock.rs
@@ -2,8 +2,8 @@
 //!
 //! Run: `cargo run -p id_effect_tokio --example 108_tokio_clock`
 
-use effect_tokio::{TokioRuntime, run_async, yield_now};
 use id_effect::Runtime;
+use id_effect_tokio::{TokioRuntime, run_async, yield_now};
 use std::time::Duration;
 
 fn main() {

--- a/crates/id_effect_tokio/examples/109_tokio_end_to_end.rs
+++ b/crates/id_effect_tokio/examples/109_tokio_end_to_end.rs
@@ -2,8 +2,8 @@
 //!
 //! Run: `cargo run -p id_effect_tokio --example 109_tokio_end_to_end`
 
-use effect_tokio::{TokioRuntime, yield_now};
 use id_effect::{Effect, Runtime, Skip1, Skip2, Stream, ctx, effect, req, run_async, succeed};
+use id_effect_tokio::{TokioRuntime, yield_now};
 use std::time::Duration;
 
 id_effect::service_key!(struct ApiBaseUrlKey);

--- a/crates/id_effect_tower/Cargo.toml
+++ b/crates/id_effect_tower/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "id_effect_tower"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Tower Service bridge for `effect` programs (runs effects via id_effect_tokio)"
 license = "CC-BY-SA-4.0"
@@ -14,11 +14,11 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [lib]
-name = "effect_tower"
+name = "id_effect_tower"
 
 [dependencies]
 id_effect = { path = "../id_effect", version = "0.1.0" }
-id_effect_tokio = { path = "../id_effect_tokio", version = "0.1.0" }
+id_effect_tokio = { path = "../id_effect_tokio", version = "0.1.1" }
 tokio = { version = "1", features = ["sync"] }
 # 0.5.0 does not build under minimal-version resolution (const / Identity::new).
 tower = { version = "0.5.3", features = ["util"] }

--- a/crates/id_effect_tower/examples/001_effect_service.rs
+++ b/crates/id_effect_tower/examples/001_effect_service.rs
@@ -1,14 +1,14 @@
-//! Minimal [`effect_tower::EffectService`]: map a request to an [`id_effect::Effect`] and run it with
-//! [`effect_tokio::run_async`] inside Tower’s [`tower::Service::call`].
+//! Minimal [`id_effect_tower::EffectService`]: map a request to an [`id_effect::Effect`] and run it with
+//! [`id_effect_tokio::run_async`] inside Tower’s [`tower::Service::call`].
 //!
 //! Uses `#[tokio::main(flavor = "current_thread")]` because the response future from
-//! [`EffectService`](effect_tower::EffectService) is not `Send` (see crate docs).
+//! [`EffectService`](id_effect_tower::EffectService) is not `Send` (see crate docs).
 //!
 //! Run: `cargo run -p id_effect_tower --example 001_effect_service`
 //! Or: `moon run effect-tower:examples`
 
-use effect_tower::EffectService;
 use id_effect::succeed;
+use id_effect_tower::EffectService;
 use tower::{Service, ServiceExt};
 
 #[tokio::main(flavor = "current_thread")]

--- a/crates/id_effect_tower/examples/002_shared_counter.rs
+++ b/crates/id_effect_tower/examples/002_shared_counter.rs
@@ -10,8 +10,8 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use effect_tower::EffectService;
 use id_effect::succeed;
+use id_effect_tower::EffectService;
 use tower::{Service, ServiceExt};
 
 #[tokio::main(flavor = "current_thread")]

--- a/crates/id_effect_tower/src/lib.rs
+++ b/crates/id_effect_tower/src/lib.rs
@@ -1,9 +1,9 @@
 //! [`tower::Service`] implementations that run [`id_effect::Effect`] programs using
-//! [`effect_tokio::run_async`], so handlers stay in the Effect interpreter while composing with
+//! [`id_effect_tokio::run_async`], so handlers stay in the Effect interpreter while composing with
 //! Tower middleware stacks.
 //!
 //! This crate depends on **`id_effect_tokio`** for the async runtime bridge; it does not re-export
-//! [`effect_tokio::TokioRuntime`].
+//! [`id_effect_tokio::TokioRuntime`].
 //!
 //! ## Concurrency
 //!
@@ -31,9 +31,9 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use effect_tokio::run_async as run_effect_async;
 use id_effect::duration::Duration;
 use id_effect::{Effect, Metric, QueueError, SynchronizedRef, box_future};
+use id_effect_tokio::run_async as run_effect_async;
 use tokio::sync::{AcquireError, OwnedSemaphorePermit, Semaphore};
 use tower::Service;
 

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1774190397,
-        "narHash": "sha256-+bfRcZN48q4LXmJEkHxOEnUqdZuqOLwPERTFVR1u9X8=",
+        "lastModified": 1776354588,
+        "narHash": "sha256-NOsJcVAG63emvdlQSpSGQjvHHxcGDfBHd/cgtpduerw=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "0b667e6d972445c285cbc8b5a6a01900555d3be5",
+        "rev": "d7aba90c41ee261d215cbe09cf92393cc0ff2606",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774104215,
-        "narHash": "sha256-EAtviqz0sEAxdHS4crqu7JGR5oI3BwaqG0mw7CmXkO8=",
+        "lastModified": 1775585728,
+        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f799ae951fde0627157f40aec28dec27b22076d0",
+        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         "nixpkgs-src": "nixpkgs-src"
       },
       "locked": {
-        "lastModified": 1773704619,
-        "narHash": "sha256-LKtmit8Sr81z8+N2vpIaN/fyiQJ8f7XJ6tMSKyDVQ9s=",
+        "lastModified": 1776348333,
+        "narHash": "sha256-ZyrYhlLGGuN5ieW7pE65meJJYnNz5el9vJtGBEJyDMQ=",
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "906534d75b0e2fe74a719559dfb1ad3563485f43",
+        "rev": "efff47329167854ce48541c7ef731bf120753c7e",
         "type": "github"
       },
       "original": {
@@ -98,11 +98,11 @@
     "nixpkgs-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1773597492,
-        "narHash": "sha256-hQ284SkIeNaeyud+LS0WVLX+WL2rxcVZLFEaK0e03zg=",
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a07d4ce6bee67d7c838a8a5796e75dff9caa21ef",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
         "type": "github"
       },
       "original": {
@@ -127,11 +127,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776136407,
-        "narHash": "sha256-Cp8XrVLGruSDBTRs8L4LmvaEcd76tHHU9esLk7Ysa4E=",
+        "lastModified": 1776350315,
+        "narHash": "sha256-ijD4bgb5Iyap9F3MX73vLAZF/SYu+q7Gd7Ux4cbfCWw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "753568957a87312ed599cba5699e67126eded6c0",
+        "rev": "62e3b8aedabc240e5b0cc9fae003bc9edfebbc9b",
         "type": "github"
       },
       "original": {

--- a/moon.yml
+++ b/moon.yml
@@ -12,7 +12,8 @@ workspace:
 tasks:
   format:
     description: 'Format the workspace with treefmt (Rust, Nix, shell, JS/TS, YAML, TOML)'
-    command: 'treefmt'
+    command: 'bash'
+    args: ['scripts/treefmt-moon.sh']
     inputs:
       - 'treefmt.toml'
       - '**/*.rs'
@@ -28,8 +29,8 @@ tasks:
   ci-format:
     description: >-
       Repo-wide format *check* (treefmt CI mode + fail-on-change). Cached so :check/:test can cache-hit; use :format to actually write formatted files.
-    command: 'treefmt'
-    args: ['--ci', '--config-file', 'treefmt.ci.toml']
+    command: 'bash'
+    args: ['scripts/treefmt-moon.sh', '--ci', '--config-file', 'treefmt.ci.toml']
     inputs:
       - 'treefmt.ci.toml'
       - '**/*.rs'

--- a/scripts/treefmt-moon.sh
+++ b/scripts/treefmt-moon.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Moon tasks call this instead of `treefmt` directly so `moon run :check` works when
+# treefmt is only provided by the dev shell (devenv.nix). CI installs treefmt on PATH.
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/.." && pwd)"
+cd "$root"
+if command -v treefmt >/dev/null 2>&1; then
+    exec treefmt "$@"
+fi
+if command -v devenv >/dev/null 2>&1; then
+    exec devenv shell -- treefmt "$@"
+fi
+echo "treefmt: command not found. Enter the dev shell (treefmt is in devenv.nix), e.g.:" >&2
+echo "  devenv shell -- moon run :check" >&2
+exit 127


### PR DESCRIPTION
- Rename lib targets to match package names (e.g. id_effect_axum).
- Bump patch versions and path dependency constraints across crates.
- Add scripts/treefmt-moon.sh so effect:ci-format/format invoke treefmt via devenv when treefmt is not on PATH.
- Refresh devenv.lock.