### PR TITLE
feat(otel): add id_effect_opentelemetry Phase B integration

### DIFF
--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -3,6 +3,7 @@ $schema: https://moonrepo.dev/schemas/workspace.json
 projects:
   effect: '.'
   id_effect_lib: crates/id_effect
+  id_effect_opentelemetry: crates/id_effect_opentelemetry
   id_effect_platform: crates/id_effect_platform
   id_effect_axum: crates/id_effect_axum
   id_effect_config: crates/id_effect_config

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 exclude = [".tmp", "tmp", "crates/id_effect_lint"]
 members = [
   "crates/id_effect",
+  "crates/id_effect_opentelemetry",
   "crates/id_effect_platform",
   "crates/id_effect_axum",
   "crates/id_effect_config",

--- a/crates/id_effect/book/src/SUMMARY.md
+++ b/crates/id_effect/book/src/SUMMARY.md
@@ -49,6 +49,7 @@
   - [Tower service (`id_effect_tower`)](./part2/ch07-09-tower-service.md)
   - [Configuration (`id_effect_config`)](./part2/ch07-10-config.md)
   - [Logging (`id_effect_logger`)](./part2/ch07-11-logger.md)
+  - [OpenTelemetry (`id_effect_opentelemetry`)](./part2/ch07-12-opentelemetry.md)
 
 # Part III: Real Programs
 

--- a/crates/id_effect/book/src/part2/ch07-12-opentelemetry.md
+++ b/crates/id_effect/book/src/part2/ch07-12-opentelemetry.md
@@ -1,0 +1,86 @@
+# OpenTelemetry (`id_effect_opentelemetry`)
+
+The workspace crate **`id_effect_opentelemetry`** implements **Phase B** of the Effect.ts parity plan:
+first-class **OpenTelemetry** traces and metrics alongside `id_effect`’s fiber-local
+[`with_span`](https://docs.rs/id_effect/latest/id_effect/fn.with_span.html) and
+[`Metric`](https://docs.rs/id_effect/latest/id_effect/struct.Metric.html) primitives.
+
+Design goals match [`@effect/opentelemetry`](https://www.npmjs.com/package/@effect/opentelemetry):
+
+- **Opt-in at the dependency boundary** — the core `id_effect` crate does not depend on OTEL.
+- **Tracing** — bridge `tracing` spans to OTEL exporters (OTLP in production; in-memory in tests).
+- **Propagation** — W3C Trace Context (`traceparent` / `tracestate`) on portable header maps.
+- **Metrics** — dual-write bridges from `Metric` counters and duration histograms to OTEL instruments.
+
+## Tracing: compose `with_span` and OTEL
+
+Use [`id_effect_opentelemetry::with_span_otel`](https://docs.rs/id_effect_opentelemetry/latest/id_effect_opentelemetry/fn.with_span_otel.html)
+when you want **both**:
+
+1. Fiber-local span stack and `EffectEvent` stream (`id_effect::with_span`), and
+2. A `tracing` span exported through [`tracing_opentelemetry`](https://docs.rs/tracing-opentelemetry).
+
+Build a tracer provider (here: in-memory for tests), install a `tracing` subscriber with an OTEL layer,
+then run effects under `with_span_otel`:
+
+```rust
+use id_effect::{install_tracing_layer, run_blocking, succeed, TracingConfig};
+use id_effect_opentelemetry::{
+  sdk_tracer_provider_with_in_memory_exporter, trace_subscriber_for_provider, with_span_otel,
+};
+use opentelemetry_sdk::trace::InMemorySpanExporter;
+
+let exporter = InMemorySpanExporter::default();
+let provider = sdk_tracer_provider_with_in_memory_exporter(&exporter);
+let subscriber = trace_subscriber_for_provider(&provider, false);
+
+tracing::subscriber::with_default(subscriber, || {
+  let _ = run_blocking(install_tracing_layer(TracingConfig::enabled()), ());
+  let eff = with_span_otel("request", succeed::<(), (), ()>(()));
+  let _ = run_blocking(eff, ());
+});
+
+let _ = provider.force_flush();
+# let _ = provider.shutdown();
+```
+
+In production you typically:
+
+1. Configure an OTLP exporter (or another `SpanExporter`) on [`SdkTracerProvider`](https://docs.rs/opentelemetry_sdk/latest/opentelemetry_sdk/trace/struct.SdkTracerProvider.html).
+2. Call [`register_global_tracer_provider`](https://docs.rs/id_effect_opentelemetry/latest/id_effect_opentelemetry/fn.register_global_tracer_provider.html) once at startup.
+3. Install a global [`tracing_subscriber`](https://docs.rs/tracing-subscriber) stack with
+   [`tracing_opentelemetry::layer()`](https://docs.rs/tracing-opentelemetry/latest/tracing_opentelemetry/fn.layer.html).
+
+## W3C Trace Context on header maps
+
+For HTTP clients built on `Vec<(String, String)>` (or similar), use:
+
+- [`install_w3c_trace_context_propagator`](https://docs.rs/id_effect_opentelemetry/latest/id_effect_opentelemetry/fn.install_w3c_trace_context_propagator.html) once per process.
+- [`inject_trace_context_into_headers`](https://docs.rs/id_effect_opentelemetry/latest/id_effect_opentelemetry/fn.inject_trace_context_into_headers.html) before sending a downstream request.
+- [`extract_trace_context_from_headers`](https://docs.rs/id_effect_opentelemetry/latest/id_effect_opentelemetry/fn.extract_trace_context_from_headers.html) when handling an incoming request.
+
+For Axum / `http::HeaderMap`, map headers into this shape at the boundary or add a small adapter in your app.
+
+## Metrics: `CounterBridge` and `DurationHistogramBridge`
+
+[`CounterBridge`](https://docs.rs/id_effect_opentelemetry/latest/id_effect_opentelemetry/struct.CounterBridge.html) and
+[`DurationHistogramBridge`](https://docs.rs/id_effect_opentelemetry/latest/id_effect_opentelemetry/struct.DurationHistogramBridge.html)
+keep `id_effect::Metric` snapshots for tests while exporting measurements to OTEL.
+
+Create an [`SdkMeterProvider`](https://docs.rs/opentelemetry_sdk/latest/opentelemetry_sdk/metrics/struct.SdkMeterProvider.html)
+with a [`PeriodicReader`](https://docs.rs/opentelemetry_sdk/latest/opentelemetry_sdk/metrics/struct.PeriodicReader.html)
+and an [`InMemoryMetricExporter`](https://docs.rs/opentelemetry_sdk/latest/opentelemetry_sdk/metrics/struct.InMemoryMetricExporter.html)
+for CI-style assertions, or wire an OTLP metrics exporter for production.
+
+**Cardinality:** keep label sets small and stable; prefer bounded `service`, `route`, `tenant` keys over
+high-cardinality user IDs in metric attributes.
+
+## Axum + Tokio production sketch
+
+1. Build tracer + meter providers with OTLP endpoints from `id_effect_config` (or env).
+2. Register globals and `try_init` a `tracing_subscriber` registry (fmt + OTEL + optional `EnvFilter`).
+3. In Axum middleware, extract `traceparent` into an OTEL [`Context`](https://docs.rs/opentelemetry/latest/opentelemetry/struct.Context.html),
+   attach it to the request extension, and spawn handler work inside that context.
+4. On graceful shutdown, call `force_flush` / `shutdown` on providers (mirror `Scope` finalizer patterns from `id_effect`).
+
+See also: `docs/effect-ts-parity/phases/phase-b-opentelemetry.md` in the repository for the full task breakdown and Beads slug map.

--- a/crates/id_effect_opentelemetry/Cargo.toml
+++ b/crates/id_effect_opentelemetry/Cargo.toml
@@ -27,7 +27,9 @@ opentelemetry_sdk = { version = "0.31", default-features = false, features = [
 ] }
 # Minimum version that introduced the `wrappers` module required by opentelemetry_sdk's rt-tokio feature.
 # This fixes `cargo -Z minimal-versions` which otherwise resolves tokio-stream to 0.1.0 (no wrappers).
-tokio-stream = { version = "0.1.3", default-features = false, features = ["time"] }
+tokio-stream = { version = "0.1.3", default-features = false, features = [
+  "time",
+] }
 tracing = "0.1"
 tracing-opentelemetry = "0.32"
 tracing-subscriber = { version = "0.3", default-features = false, features = [

--- a/crates/id_effect_opentelemetry/Cargo.toml
+++ b/crates/id_effect_opentelemetry/Cargo.toml
@@ -25,6 +25,9 @@ opentelemetry_sdk = { version = "0.31", default-features = false, features = [
   "rt-tokio",
   "testing",
 ] }
+# Minimum version that introduced the `wrappers` module required by opentelemetry_sdk's rt-tokio feature.
+# This fixes `cargo -Z minimal-versions` which otherwise resolves tokio-stream to 0.1.0 (no wrappers).
+tokio-stream = { version = "0.1.3", default-features = false, features = ["time"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.32"
 tracing-subscriber = { version = "0.3", default-features = false, features = [

--- a/crates/id_effect_opentelemetry/Cargo.toml
+++ b/crates/id_effect_opentelemetry/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "id_effect_opentelemetry"
+version = "0.2.0"
+edition = "2024"
+license = "CC-BY-SA-4.0"
+description = "OpenTelemetry tracing and metrics integration for id_effect (Phase B / @effect/opentelemetry parity)"
+repository = "https://github.com/Industrial/id_effect"
+readme = "README.md"
+keywords = ["effect", "opentelemetry", "tracing", "observability"]
+categories = ["development-tools"]
+
+[lints.rust]
+unsafe_code = "forbid"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }
+
+[dependencies]
+id_effect = { path = "../id_effect", version = "0.2.0" }
+opentelemetry = { version = "0.31", default-features = false, features = [
+  "trace",
+  "metrics",
+] }
+opentelemetry_sdk = { version = "0.31", default-features = false, features = [
+  "trace",
+  "metrics",
+  "rt-tokio",
+  "testing",
+] }
+tracing = "0.1"
+tracing-opentelemetry = "0.32"
+tracing-subscriber = { version = "0.3", default-features = false, features = [
+  "registry",
+  "fmt",
+  "std",
+] }
+
+[dev-dependencies]
+tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread"] }

--- a/crates/id_effect_opentelemetry/README.md
+++ b/crates/id_effect_opentelemetry/README.md
@@ -1,0 +1,40 @@
+# `id_effect_opentelemetry`
+
+Phase B integration: **OpenTelemetry** traces and metrics alongside `id_effect`’s built-in
+[`with_span`](https://docs.rs/id_effect/latest/id_effect/fn.with_span.html) and
+[`Metric`](https://docs.rs/id_effect/latest/id_effect/struct.Metric.html) helpers.
+
+See the mdBook chapter **“OpenTelemetry (`id_effect_opentelemetry`)”** and
+[`docs/effect-ts-parity/phases/phase-b-opentelemetry.md`](../../docs/effect-ts-parity/phases/phase-b-opentelemetry.md).
+
+## Highlights
+
+- **`with_span_otel`**: composes `id_effect::with_span` with a `tracing` span exported via OTEL.
+- **W3C `traceparent`**: inject/extract helpers for portable HTTP header maps.
+- **Metric bridges**: dual-write from `Metric` counters/histograms to OTEL instruments.
+- **Test harness**: in-memory span exporter + scoped `tracing` subscriber (no global clashes).
+
+## Usage sketch
+
+```rust
+use id_effect_opentelemetry::{
+  install_w3c_trace_context_propagator, sdk_tracer_provider_with_in_memory_exporter,
+  with_span_otel,
+};
+use id_effect::{run_blocking, succeed, install_tracing_layer, TracingConfig};
+
+let exporter = opentelemetry_sdk::trace::InMemorySpanExporter::default();
+let provider = sdk_tracer_provider_with_in_memory_exporter(&exporter);
+let tracer = provider.tracer("my_app");
+let layer = tracing_opentelemetry::layer().with_tracer(tracer);
+let subscriber = tracing_subscriber::Registry::default().with(layer);
+
+tracing::subscriber::with_default(subscriber, || {
+  let _ = run_blocking(install_tracing_layer(TracingConfig::enabled()), ());
+  let eff = with_span_otel("work", succeed::<u32, (), ()>(1));
+  let _ = run_blocking(eff, ());
+});
+```
+
+Production setups typically register a global tracer provider, OTLP exporters, and a
+`tracing_subscriber` stack at process start; see the mdBook chapter for Axum + Tokio notes.

--- a/crates/id_effect_opentelemetry/examples/otel_minimal.rs
+++ b/crates/id_effect_opentelemetry/examples/otel_minimal.rs
@@ -1,0 +1,25 @@
+//! Minimal example: in-memory OTEL trace export + `with_span_otel`.
+//!
+//! Run: `cargo run -p id_effect_opentelemetry --example otel_minimal`
+
+use id_effect::{TracingConfig, install_tracing_layer, run_blocking, succeed};
+use id_effect_opentelemetry::{
+  sdk_tracer_provider_with_in_memory_exporter, trace_subscriber_for_provider, with_span_otel,
+};
+use opentelemetry_sdk::trace::InMemorySpanExporter;
+
+fn main() {
+  let exporter = InMemorySpanExporter::default();
+  let provider = sdk_tracer_provider_with_in_memory_exporter(&exporter);
+  let subscriber = trace_subscriber_for_provider(&provider, true);
+  let _guard = tracing::subscriber::set_default(subscriber);
+
+  let _ = run_blocking(install_tracing_layer(TracingConfig::enabled()), ());
+  let eff = with_span_otel("example.work", succeed::<(), (), ()>(()));
+  let _ = run_blocking(eff, ());
+
+  let _ = provider.force_flush();
+  let spans = exporter.get_finished_spans().expect("read spans");
+  println!("exported spans: {}", spans.len());
+  let _ = provider.shutdown();
+}

--- a/crates/id_effect_opentelemetry/moon.yml
+++ b/crates/id_effect_opentelemetry/moon.yml
@@ -1,0 +1,87 @@
+# https://moonrepo.dev/docs/config/project
+language: 'rust'
+layer: 'library'
+tasks:
+  check:
+    deps: ['effect:ci-format', '^:check']
+    command:
+      - cargo
+      - check
+      - -p
+      - id_effect_opentelemetry
+      - --all-targets
+      - --all-features
+    inputs:
+      - 'Cargo.toml'
+      - 'src/**/*.rs'
+      - 'tests/**/*.rs'
+      - 'examples/**/*.rs'
+    options:
+      cache: true
+      outputStyle: buffer-only-failure
+  clippy:
+    deps: ['^:clippy', '~:check']
+    command:
+      - cargo
+      - clippy
+      - -p
+      - id_effect_opentelemetry
+      - --all-targets
+      - --all-features
+      - --
+      - -D
+      - warnings
+    inputs:
+      - 'Cargo.toml'
+      - 'src/**/*.rs'
+      - 'tests/**/*.rs'
+      - 'examples/**/*.rs'
+    options:
+      cache: true
+      outputStyle: buffer-only-failure
+  test:
+    deps: ['^:test', '~:clippy']
+    command:
+      - cargo
+      - nextest
+      - run
+      - -p
+      - id_effect_opentelemetry
+    inputs:
+      - 'Cargo.toml'
+      - 'src/**/*.rs'
+      - 'tests/**/*.rs'
+    options:
+      cache: true
+      outputStyle: buffer-only-failure
+  build:
+    deps: ['^:build', '~:test']
+    command:
+      - cargo
+      - build
+      - -p
+      - id_effect_opentelemetry
+      - --all-targets
+      - --all-features
+    inputs:
+      - 'Cargo.toml'
+      - 'src/**/*.rs'
+      - 'tests/**/*.rs'
+      - 'examples/**/*.rs'
+    options:
+      cache: true
+      outputStyle: buffer-only-failure
+  examples:
+    description: 'Run all crate example binaries (examples/*.rs); no-op if none'
+    deps: ['~:test']
+    command: 'bash'
+    args:
+      - '../../scripts/moon-run-crate-examples.sh'
+      - 'id_effect_opentelemetry'
+    inputs:
+      - 'Cargo.toml'
+      - 'src/**/*.rs'
+      - 'examples/**/*.rs'
+    options:
+      cache: true
+      outputStyle: buffer-only-failure

--- a/crates/id_effect_opentelemetry/src/lib.rs
+++ b/crates/id_effect_opentelemetry/src/lib.rs
@@ -1,0 +1,35 @@
+//! OpenTelemetry integration for [`id_effect`]: tracing spans, W3C propagation, and metric bridges.
+//!
+//! This crate is the Phase B (`@effect/opentelemetry` parity) integration layer. It stays **opt-in**
+//! at the dependency level: the core `id_effect` crate does not pull OpenTelemetry.
+//!
+//! ## Areas
+//!
+//! - **Span bridge** — compose [`id_effect::with_span`] with `tracing` spans exported to OTEL.
+//! - **Propagation** — W3C Trace Context (`traceparent` / `tracestate`) on header maps.
+//! - **Subscriber helpers** — build [`opentelemetry_sdk::trace::SdkTracerProvider`] for tests and apps.
+//! - **Metric bridges** — dual-write [`id_effect::Metric`] instruments to OTEL.
+//!
+//! ## Testing
+//!
+//! Prefer [`trace_subscriber_for_provider`] with [`tracing::subscriber::with_default`] in unit tests
+//! so the global tracing dispatcher is not permanently claimed. See unit tests in each module.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+mod metrics_bridge;
+mod propagation;
+mod span_bridge;
+mod subscriber;
+
+pub use metrics_bridge::{CounterBridge, DurationHistogramBridge};
+pub use propagation::{
+  extract_trace_context_from_headers, inject_trace_context_into_headers,
+  install_w3c_trace_context_propagator,
+};
+pub use span_bridge::with_span_otel;
+pub use subscriber::{
+  register_global_tracer_provider, sdk_tracer_provider_with_in_memory_exporter,
+  trace_subscriber_for_provider, try_init_global_tracing_with_otel,
+};

--- a/crates/id_effect_opentelemetry/src/metrics_bridge.rs
+++ b/crates/id_effect_opentelemetry/src/metrics_bridge.rs
@@ -1,0 +1,161 @@
+//! Bridges [`id_effect::Metric`] instruments to OpenTelemetry metrics (MVP: counter + duration histogram).
+
+use id_effect::Metric;
+use id_effect::kernel::Effect;
+use id_effect::runtime::{Never, run_blocking};
+use id_effect::scheduling::Duration;
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::{Histogram, Meter};
+use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
+
+fn tags_to_kv(tags: &[(String, String)]) -> Vec<KeyValue> {
+  tags
+    .iter()
+    .map(|(k, v)| KeyValue::new(k.clone(), v.clone()))
+    .collect()
+}
+
+/// Dual-writes [`Metric::counter`] updates and an OpenTelemetry `u64` counter.
+#[derive(Clone)]
+pub struct CounterBridge {
+  local: Metric<u64, ()>,
+  otel: opentelemetry::metrics::Counter<u64>,
+}
+
+impl CounterBridge {
+  /// Builds a bridge from an existing `id_effect` counter and an OTEL instrument on `meter`.
+  pub fn new(local: Metric<u64, ()>, meter: &Meter, otel_name: &'static str) -> Self {
+    let otel = meter.u64_counter(otel_name).build();
+    Self { local, otel }
+  }
+
+  /// Increments both the in-process counter and the OTEL counter by `delta`.
+  pub fn apply(&self, delta: u64) -> Effect<(), Never, ()> {
+    let local = self.local.clone();
+    let otel = self.otel.clone();
+    let attrs = tags_to_kv(self.local.tags());
+    Effect::new(move |_env| {
+      run_blocking(local.apply(delta), ())?;
+      otel.add(delta, attrs.as_slice());
+      Ok(())
+    })
+  }
+
+  /// Snapshot of the `id_effect` counter (OTEL side is observed via exporters).
+  #[inline]
+  pub fn snapshot_local(&self) -> u64 {
+    self.local.snapshot_count()
+  }
+}
+
+/// Dual-writes [`Metric`] duration histogram observations and an OTEL `f64` histogram (milliseconds).
+#[derive(Clone)]
+pub struct DurationHistogramBridge {
+  local: Metric<Duration, ()>,
+  otel: Histogram<f64>,
+}
+
+impl DurationHistogramBridge {
+  /// Builds a bridge from an `id_effect` histogram and an OTEL histogram on `meter`.
+  pub fn new(local: Metric<Duration, ()>, meter: &Meter, otel_name: &'static str) -> Self {
+    let otel = meter.f64_histogram(otel_name).build();
+    Self { local, otel }
+  }
+
+  /// Records the same duration sample on both sides (`id_effect` + OTEL, as milliseconds).
+  pub fn apply(&self, sample: Duration) -> Effect<(), Never, ()> {
+    let local = self.local.clone();
+    let otel = self.otel.clone();
+    let attrs = tags_to_kv(self.local.tags());
+    Effect::new(move |_env| {
+      run_blocking(local.apply(sample), ())?;
+      let ms = sample.as_secs_f64() * 1_000.0;
+      otel.record(ms, attrs.as_slice());
+      Ok(())
+    })
+  }
+
+  /// Snapshot of recorded durations on the `id_effect` side.
+  #[inline]
+  pub fn snapshot_local_durations(&self) -> Vec<Duration> {
+    self.local.snapshot_durations()
+  }
+}
+
+/// Test helper: meter provider with periodic export to memory.
+///
+/// This is primarily for tests and local spikes; it is not referenced from non-test library code,
+/// so it may trigger `dead_code` in `cargo check` of the library target alone.
+#[allow(dead_code)]
+pub fn test_meter_provider_with_in_memory_exporter(
+  exporter: &InMemoryMetricExporter,
+) -> SdkMeterProvider {
+  let reader = PeriodicReader::builder(exporter.clone()).build();
+  SdkMeterProvider::builder().with_reader(reader).build()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use id_effect::run_blocking;
+  use opentelemetry::metrics::MeterProvider;
+
+  mod counter_bridge {
+    use super::*;
+
+    #[test]
+    fn apply_updates_local_and_emits_otel_metric_after_flush() {
+      let exporter = InMemoryMetricExporter::default();
+      let mp = test_meter_provider_with_in_memory_exporter(&exporter);
+      let meter = mp.meter("test");
+      let local = Metric::counter("requests", Vec::<(String, String)>::new());
+      let bridge = CounterBridge::new(local.clone(), &meter, "requests_otel");
+      let _ = run_blocking(bridge.apply(3), ());
+      let _ = mp.force_flush();
+      assert_eq!(bridge.snapshot_local(), 3);
+      let finished = exporter.get_finished_metrics().expect("metrics");
+      assert!(
+        !finished.is_empty(),
+        "expected at least one ResourceMetrics after flush, got {finished:?}"
+      );
+      let _ = mp.shutdown();
+    }
+  }
+
+  mod duration_histogram_bridge {
+    use super::*;
+
+    #[test]
+    fn apply_records_on_both_sides() {
+      let exporter = InMemoryMetricExporter::default();
+      let mp = test_meter_provider_with_in_memory_exporter(&exporter);
+      let meter = mp.meter("test");
+      let local = Metric::histogram("latency", Vec::<(String, String)>::new());
+      let bridge = DurationHistogramBridge::new(local.clone(), &meter, "latency_ms");
+      let d = Duration::from_millis(12);
+      let _ = run_blocking(bridge.apply(d), ());
+      let _ = mp.force_flush();
+      assert_eq!(bridge.snapshot_local_durations().len(), 1);
+      let finished = exporter.get_finished_metrics().expect("metrics");
+      assert!(!finished.is_empty());
+      let _ = mp.shutdown();
+    }
+  }
+
+  mod counter_bridge_with_tags {
+    use super::*;
+
+    #[test]
+    fn forwards_tag_pairs_as_otel_attributes() {
+      let exporter = InMemoryMetricExporter::default();
+      let mp = test_meter_provider_with_in_memory_exporter(&exporter);
+      let meter = mp.meter("test");
+      let pairs = vec![("svc".to_string(), "api".to_string())];
+      let local = Metric::counter("c", pairs);
+      let bridge = CounterBridge::new(local, &meter, "c_otel");
+      let _ = run_blocking(bridge.apply(1), ());
+      let _ = mp.force_flush();
+      let _ = mp.shutdown();
+    }
+  }
+}

--- a/crates/id_effect_opentelemetry/src/propagation.rs
+++ b/crates/id_effect_opentelemetry/src/propagation.rs
@@ -1,0 +1,111 @@
+//! W3C Trace Context propagation on simple `(String, String)` header maps (MVP for HTTP clients).
+
+use opentelemetry::Context;
+use opentelemetry::propagation::{Extractor, Injector};
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+
+/// Installs the W3C Trace Context propagator as the global text-map propagator.
+///
+/// Safe to call once per process; subsequent calls replace the previous propagator.
+pub fn install_w3c_trace_context_propagator() {
+  opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+}
+
+struct VecHeadersInjector<'a>(&'a mut Vec<(String, String)>);
+
+impl Injector for VecHeadersInjector<'_> {
+  fn set(&mut self, key: &str, value: String) {
+    self.0.retain(|(k, _)| !k.eq_ignore_ascii_case(key));
+    self.0.push((key.to_string(), value));
+  }
+}
+
+/// Carrier for [`Extractor`] over immutable header slices.
+pub struct VecHeadersExtractor<'a> {
+  headers: &'a [(String, String)],
+}
+
+impl<'a> VecHeadersExtractor<'a> {
+  /// Wraps a borrowed header list for extraction.
+  pub fn new(headers: &'a [(String, String)]) -> Self {
+    Self { headers }
+  }
+}
+
+impl Extractor for VecHeadersExtractor<'_> {
+  fn get(&self, key: &str) -> Option<&str> {
+    self.headers.iter().find_map(|(k, v)| {
+      if k.eq_ignore_ascii_case(key) {
+        Some(v.as_str())
+      } else {
+        None
+      }
+    })
+  }
+
+  fn keys(&self) -> Vec<&str> {
+    self.headers.iter().map(|(k, _)| k.as_str()).collect()
+  }
+}
+
+/// Injects the current [`Context`] trace state into `headers` using the global text-map propagator.
+pub fn inject_trace_context_into_headers(cx: &Context, headers: &mut Vec<(String, String)>) {
+  let mut inj = VecHeadersInjector(headers);
+  opentelemetry::global::get_text_map_propagator(|prop| prop.inject_context(cx, &mut inj));
+}
+
+/// Extracts a [`Context`] from `headers` using the global text-map propagator, starting from `base`.
+pub fn extract_trace_context_from_headers(base: &Context, headers: &[(String, String)]) -> Context {
+  let ext = VecHeadersExtractor::new(headers);
+  opentelemetry::global::get_text_map_propagator(|prop| prop.extract_with_context(base, &ext))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use opentelemetry::trace::TracerProvider as _;
+  use opentelemetry::trace::{TraceContextExt, Tracer};
+  use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+
+  mod round_trip {
+    use super::*;
+
+    #[test]
+    fn inject_then_extract_preserves_remote_span_id() {
+      install_w3c_trace_context_propagator();
+      let exporter = InMemorySpanExporter::default();
+      let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .build();
+      let tracer = provider.tracer("propagation_test");
+      let span = tracer.start("remote");
+      let cx = opentelemetry::Context::current_with_span(span);
+      let mut headers = Vec::new();
+      inject_trace_context_into_headers(&cx, &mut headers);
+      assert!(
+        headers
+          .iter()
+          .any(|(k, _)| k.eq_ignore_ascii_case("traceparent")),
+        "expected traceparent header, got {headers:?}"
+      );
+      let extracted = extract_trace_context_from_headers(&Context::default(), &headers);
+      let span_ctx = extracted.span().span_context().clone();
+      assert!(span_ctx.is_valid(), "expected valid span context");
+      let _ = provider.shutdown();
+    }
+  }
+
+  mod vec_headers_extractor {
+    use super::*;
+
+    #[test]
+    fn get_is_case_insensitive_for_header_name() {
+      let headers = vec![(
+        "TraceParent".to_string(),
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string(),
+      )];
+      let ext = VecHeadersExtractor::new(&headers);
+      assert!(ext.get("traceparent").is_some());
+    }
+  }
+}

--- a/crates/id_effect_opentelemetry/src/span_bridge.rs
+++ b/crates/id_effect_opentelemetry/src/span_bridge.rs
@@ -1,0 +1,80 @@
+//! Bridge [`id_effect::with_span`] with `tracing` spans so OTEL exporters see effect-scoped work.
+
+use id_effect::{Effect, box_future};
+use tracing::Instrument;
+
+/// Runs `effect` under both [`id_effect::with_span`] (fiber-local stack + effect events) and a
+/// `tracing` span (exported to OpenTelemetry when a [`tracing_subscriber`] with
+/// [`tracing_opentelemetry`] is installed).
+///
+/// The `name` must match the `id_effect` API (`&'static str`) and is also attached as tracing
+/// metadata under `otel.span_name`.
+pub fn with_span_otel<A, E, R>(name: &'static str, effect: Effect<A, E, R>) -> Effect<A, E, R>
+where
+  A: 'static,
+  E: 'static,
+  R: 'static,
+{
+  let inner = id_effect::with_span(effect, name);
+  Effect::new_async(move |env: &mut R| {
+    let span = tracing::trace_span!("id_effect.effect", otel.span_name = name);
+    box_future(async move { inner.run(env).instrument(span).await })
+  })
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::subscriber::{
+    sdk_tracer_provider_with_in_memory_exporter, trace_subscriber_for_provider,
+  };
+  use id_effect::{TracingConfig, install_tracing_layer, run_blocking, succeed};
+  use opentelemetry_sdk::trace::InMemorySpanExporter;
+
+  mod with_span_otel_when_tracing_stack_configured {
+    use super::*;
+
+    #[test]
+    fn emits_tracing_span_exported_to_otel() {
+      let exporter = InMemorySpanExporter::default();
+      let provider = sdk_tracer_provider_with_in_memory_exporter(&exporter);
+      let subscriber = trace_subscriber_for_provider(&provider, false);
+      tracing::subscriber::with_default(subscriber, || {
+        let _ = run_blocking(install_tracing_layer(TracingConfig::enabled()), ());
+        let eff = with_span_otel("otel.inner", succeed::<(), (), ()>(()));
+        let _ = run_blocking(eff, ());
+      });
+      let _ = provider.force_flush();
+      let spans = exporter.get_finished_spans().expect("spans");
+      assert!(
+        spans.iter().any(|s| s.name == "id_effect.effect"),
+        "expected id_effect.effect span, got {spans:?}"
+      );
+      let _ = provider.shutdown();
+    }
+
+    #[test]
+    fn nests_inner_and_outer_spans() {
+      let exporter = InMemorySpanExporter::default();
+      let provider = sdk_tracer_provider_with_in_memory_exporter(&exporter);
+      let subscriber = trace_subscriber_for_provider(&provider, false);
+      tracing::subscriber::with_default(subscriber, || {
+        let _ = run_blocking(install_tracing_layer(TracingConfig::enabled()), ());
+        let inner = with_span_otel("inner", succeed::<(), (), ()>(()));
+        let outer = with_span_otel("outer", inner);
+        let _ = run_blocking(outer, ());
+      });
+      let _ = provider.force_flush();
+      let spans = exporter.get_finished_spans().expect("spans");
+      let effect_spans: Vec<_> = spans
+        .iter()
+        .filter(|s| s.name == "id_effect.effect")
+        .collect();
+      assert!(
+        effect_spans.len() >= 2,
+        "expected nested effect spans, got {effect_spans:?}"
+      );
+      let _ = provider.shutdown();
+    }
+  }
+}

--- a/crates/id_effect_opentelemetry/src/subscriber.rs
+++ b/crates/id_effect_opentelemetry/src/subscriber.rs
@@ -1,0 +1,108 @@
+//! Tracer provider helpers and [`tracing_subscriber`] wiring for OpenTelemetry.
+
+use opentelemetry::global;
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+use tracing::Subscriber;
+use tracing_subscriber::Registry;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+/// Builds an [`SdkTracerProvider`] that exports spans to an in-memory buffer (tests and spikes).
+pub fn sdk_tracer_provider_with_in_memory_exporter(
+  exporter: &InMemorySpanExporter,
+) -> SdkTracerProvider {
+  SdkTracerProvider::builder()
+    .with_simple_exporter(exporter.clone())
+    .build()
+}
+
+/// Registers `provider` as the process-wide OpenTelemetry tracer provider.
+///
+/// Call [`SdkTracerProvider::shutdown`] (or drop the last clone after shutdown) before replacing
+/// the global provider in long-lived binaries.
+pub fn register_global_tracer_provider(provider: &SdkTracerProvider) {
+  global::set_tracer_provider(provider.clone());
+}
+
+/// Returns a boxed [`tracing`] [`Subscriber`]: registry + OpenTelemetry layer, optionally with `fmt`.
+///
+/// Use with [`tracing::subscriber::with_default`] in tests, or [`SubscriberInitExt::try_init`] once at
+/// startup in binaries.
+pub fn trace_subscriber_for_provider(
+  provider: &SdkTracerProvider,
+  with_fmt_layer: bool,
+) -> Box<dyn Subscriber + Send + Sync + 'static> {
+  let tracer = provider.tracer("id_effect_opentelemetry");
+  let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+  if with_fmt_layer {
+    Box::new(
+      Registry::default()
+        .with(otel_layer)
+        .with(tracing_subscriber::fmt::layer()),
+    )
+  } else {
+    Box::new(Registry::default().with(otel_layer))
+  }
+}
+
+/// Installs a global subscriber built from [`trace_subscriber_for_provider`].
+///
+/// Returns `Err` if a global default was already installed (mirrors [`tracing_subscriber`] rules).
+pub fn try_init_global_tracing_with_otel(
+  provider: &SdkTracerProvider,
+  with_fmt_layer: bool,
+) -> Result<(), tracing_subscriber::util::TryInitError> {
+  trace_subscriber_for_provider(provider, with_fmt_layer).try_init()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use opentelemetry::trace::Tracer;
+
+  mod sdk_tracer_provider_with_in_memory_exporter {
+    use super::*;
+
+    #[test]
+    fn exports_finished_span_after_flush() {
+      let exporter = InMemorySpanExporter::default();
+      let provider = sdk_tracer_provider_with_in_memory_exporter(&exporter);
+      let tracer = provider.tracer("unit");
+      {
+        let span = tracer.start("hello");
+        drop(span);
+      }
+      let _ = provider.force_flush();
+      let spans = exporter.get_finished_spans().expect("spans");
+      assert!(
+        spans.iter().any(|s| s.name == "hello"),
+        "expected span named hello, got {spans:?}"
+      );
+      let _ = provider.shutdown();
+    }
+  }
+
+  mod trace_subscriber_for_provider {
+    use super::*;
+
+    #[test]
+    fn records_tracing_span_without_fmt_layer() {
+      let exporter = InMemorySpanExporter::default();
+      let provider = sdk_tracer_provider_with_in_memory_exporter(&exporter);
+      let sub = trace_subscriber_for_provider(&provider, false);
+      tracing::subscriber::with_default(sub, || {
+        let root = tracing::info_span!("root_op");
+        let _g = root.enter();
+        tracing::info!(target: "id_effect_opentelemetry", "event");
+      });
+      let _ = provider.force_flush();
+      let spans = exporter.get_finished_spans().expect("spans");
+      assert!(
+        spans.iter().any(|s| s.name == "root_op"),
+        "expected tracing span, got {spans:?}"
+      );
+      let _ = provider.shutdown();
+    }
+  }
+}

--- a/docs/effect-ts-parity/CHECKLIST-upstream-effect.md
+++ b/docs/effect-ts-parity/CHECKLIST-upstream-effect.md
@@ -17,7 +17,7 @@
 | `FiberRef` | Fiber-local state | `fiber_ref.rs` | |
 | `Cause` / `Exit` | Failure | `crates/id_effect/src/failure/` | |
 | `@effect/platform` | HTTP, FS, process | *Planned Phase A* — `docs/effect-ts-parity/phases/phase-a-unified-platform.md` | |
-| `@effect/opentelemetry` | OTEL | *Planned Phase B* | |
+| `@effect/opentelemetry` | OTEL | **Phase B** — `crates/id_effect_opentelemetry` + mdBook `part2/ch07-12-opentelemetry.md` | |
 | `@effect/sql` | Database | *Planned Phase C* | |
 | `@effect/rpc` | RPC | *Planned Phase D* | |
 | `@effect/cli` | CLI | *Planned Phase E* | |

--- a/docs/effect-ts-parity/phases/phase-b-opentelemetry.md
+++ b/docs/effect-ts-parity/phases/phase-b-opentelemetry.md
@@ -4,6 +4,8 @@
 **Effect.ts reference:** `@effect/opentelemetry` — traces, metrics, logs aligned with OTEL semantics and context propagation.  
 **Goal:** First-class **OpenTelemetry** export and **context propagation** integrated with `id_effect` fibers, spans, and existing `observability` hooks—without forcing every user to depend on OTEL in the core crate.
 
+**Implementation (workspace):** `crates/id_effect_opentelemetry` — tracing bridge (`with_span_otel`), W3C header propagation, metric bridges, and mdBook `part2/ch07-12-opentelemetry.md`.
+
 ## Executive summary
 
 `id_effect` already exposes **tracing-oriented** APIs (`with_span`, fiber events, metrics primitives). Phase B adds an **`id_effect_opentelemetry`** (name TBD) integration crate that:


### PR DESCRIPTION
Introduce workspace crate bridging id_effect tracing/metrics to OpenTelemetry (tracing-opentelemetry, W3C trace context propagation, counter/histogram bridges), mdBook chapter, example, Moon wiring, and parity doc updates.