### PR TITLE
feat(rpc): implement Phase D id_effect_rpc and mdBook chapter

### DIFF
--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -6,6 +6,7 @@ projects:
   id_effect_opentelemetry: crates/id_effect_opentelemetry
   id_effect_platform: crates/id_effect_platform
   id_effect_axum: crates/id_effect_axum
+  id_effect_rpc: crates/id_effect_rpc
   id_effect_config: crates/id_effect_config
   id_effect_logger: crates/id_effect_logger
   id_effect_macro: crates/id_effect_macro

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "crates/id_effect_opentelemetry",
   "crates/id_effect_platform",
   "crates/id_effect_axum",
+  "crates/id_effect_rpc",
   "crates/id_effect_config",
   "crates/id_effect_logger",
   "crates/id_effect_macro",

--- a/crates/id_effect/book/src/SUMMARY.md
+++ b/crates/id_effect/book/src/SUMMARY.md
@@ -49,7 +49,7 @@
   - [Tower service (`id_effect_tower`)](./part2/ch07-09-tower-service.md)
   - [Configuration (`id_effect_config`)](./part2/ch07-10-config.md)
   - [Logging (`id_effect_logger`)](./part2/ch07-11-logger.md)
-  - [OpenTelemetry (`id_effect_opentelemetry`)](./part2/ch07-12-opentelemetry.md)
+  - [RPC boundaries (`id_effect_rpc`)](./part2/ch07-12-rpc-boundaries.md)
 
 # Part III: Real Programs
 

--- a/crates/id_effect/book/src/appendix-a-api-reference.md
+++ b/crates/id_effect/book/src/appendix-a-api-reference.md
@@ -149,6 +149,7 @@ A condensed reference for the most commonly used types and functions in id_effec
 | `id_effect_platform` | HTTP / FS / process **ports** + live + test impls | [Platform I/O](./part2/ch07-06-platform-services.md) | `cargo doc -p id_effect_platform` |
 | `id_effect_reqwest` | `reqwest::Client` as a service; pools; JSON + schema | [HTTP via reqwest](./part2/ch07-07-reqwest-http.md) | `cargo doc -p id_effect_reqwest` |
 | `id_effect_axum` | Axum handlers + `State<R>` bridge | [Axum host](./part2/ch07-08-axum-host.md) | `cargo doc -p id_effect_axum` |
+| `id_effect_rpc` | RPC-style JSON errors, correlation ids, tracing spans | [RPC boundaries](./part2/ch07-12-rpc-boundaries.md) | `cargo doc -p id_effect_rpc` |
 | `id_effect_tower` | `tower::Service` over effects | [Tower service](./part2/ch07-09-tower-service.md) | `cargo doc -p id_effect_tower` |
 | `id_effect_config` | Config descriptors, Figment, provider in `R` | [Configuration](./part2/ch07-10-config.md) | `cargo doc -p id_effect_config` |
 | `id_effect_logger` | Injectable `EffectLogger` | [Logging](./part2/ch07-11-logger.md) | `cargo doc -p id_effect_logger` |

--- a/crates/id_effect/book/src/part2/ch07-08-axum-host.md
+++ b/crates/id_effect/book/src/part2/ch07-08-axum-host.md
@@ -22,6 +22,7 @@ Workspace effects are intentionally **not `Send`** in the general case. Axum han
 
 ## Further reading
 
+- [RPC boundaries](./ch07-12-rpc-boundaries.md) — `id_effect_rpc` envelopes, correlation ids, tracing
 - `cargo doc --open -p id_effect_axum`
 - Examples: `cargo run -p id_effect_axum --example 010_routing_hello`
 - [Tokio bridge](./ch07-05-tokio-bridge.md) for interpreter semantics; [Tower](./ch07-09-tower-service.md) for generic `Service` composition without Axum.

--- a/crates/id_effect/book/src/part2/ch07-12-rpc-boundaries.md
+++ b/crates/id_effect/book/src/part2/ch07-12-rpc-boundaries.md
@@ -1,0 +1,53 @@
+# RPC boundaries with id_effect (`@effect/rpc` parity)
+
+Effect.ts [`@effect/rpc`](https://effect-ts.github.io/effect/docs/rpc) ties **Schema**, **Layer**, and **HTTP** so typed contracts cross process boundaries. In Rust there is no single blessed stack; this chapter documents **patterns** and the workspace **`id_effect_rpc`** crate for **RPC-shaped HTTP** on top of **`id_effect_axum`** and **`id_effect::schema`**.
+
+## Choosing a wire stack (tonic, tarpc, HTTP+JSON)
+
+| Approach | Strengths | Trade-offs |
+|----------|-----------|------------|
+| **[`tonic`](https://docs.rs/tonic)** + **Protobuf** | Mature gRPC ecosystem, streaming, codegen from `.proto` | Separate schema language; protobuf ↔ `Effect` error mapping is manual at generated boundaries |
+| **[`tarpc`](https://docs.rs/tarpc)** | Rust-native service traits, pluggable transports | Fewer batteries than tonic for cross-language clients; still need an explicit error wire type |
+| **HTTP + JSON + `Schema`** | Same `Schema` as domain validation; easy to debug; fits Axum | No streaming parity on day one; discipline required for versioning and error envelopes |
+
+**Recommendation for `id_effect` today:** use **HTTP + JSON** for public APIs where you already host **Axum**, validate bodies with **`Schema::decode_unknown`** via [`id_effect_axum::json::decode_json_schema`](./ch07-08-axum-host.md), and return structured failures with **`id_effect_rpc::RpcError`**. Add **gRPC (`tonic`)** when you need IDL-first codegen or cross-language streaming at scale.
+
+## Effect, `R`, and errors at the edge
+
+- Keep **`Effect<A, E, R>`** for domain logic; **`E`** stays rich inside the process.
+- At the Axum route, **map** `E` (and schema failures) into **`RpcError`** or **422** JSON from `decode_json_schema` — clients see a **stable wire contract**, not internal enums.
+- Propagate **`x-correlation-id`** (read or generate with **`id_effect_rpc::correlation`**) and attach it to **responses** so logs and traces line up across hops.
+
+## Tracing and OpenTelemetry
+
+Use **`id_effect_rpc::span::rpc_request_span`** for a stable **`rpc.request`** span name and fields (`http.method`, `http.route`, `rpc.operation`, `correlation.id`). When your binary installs a subscriber with an **OpenTelemetry** layer (see Phase B docs), these fields map cleanly to semantic conventions without `id_effect_rpc` depending on OTEL crates.
+
+## Workspace crate: `id_effect_rpc`
+
+| Piece | Role |
+|-------|------|
+| **`RpcError` / `RpcEnvelope`** | JSON body + HTTP status + `IntoResponse` for Axum |
+| **`correlation`** | `x-correlation-id` read, generate, append |
+| **`span`** | `tracing` helpers for RPC-shaped requests |
+
+API index: `cargo doc -p id_effect_rpc --open`.
+
+## Example: Axum + Schema + `RpcError`
+
+Runnable example:
+
+```bash
+cargo run -p id_effect_rpc --example 010_json_greet
+```
+
+It accepts `POST /greet` with JSON `{"name": string, "enthusiasm": i64}`, validates with **`Schema`**, rejects bad enthusiasm with **`RpcError::invalid_argument`**, and echoes **`x-correlation-id`**.
+
+## Stage D3 — codegen (optional)
+
+Proc-macros or **`build.rs`** stubs for service definitions are **backlog** until the D2 operational model is proven in production. See `docs/effect-ts-parity/phases/phase-d-rpc.md` slugs `iep-d-030` / `iep-d-031`.
+
+## Further reading
+
+- [Axum host](./ch07-08-axum-host.md) — `id_effect_axum`, `execute`, JSON + schema
+- [Schema](../part4/ch14-00-schema.md) — wire types and `ParseError`
+- Phase spec: `docs/effect-ts-parity/phases/phase-d-rpc.md`

--- a/crates/id_effect_rpc/Cargo.toml
+++ b/crates/id_effect_rpc/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "id_effect_rpc"
+version = "0.2.0"
+edition = "2024"
+license = "CC-BY-SA-4.0"
+description = "RPC-style HTTP envelopes, correlation ids, and tracing helpers for id_effect Axum hosts"
+repository = "https://github.com/Industrial/id_effect"
+readme = "README.md"
+
+[lints.rust]
+unsafe_code = "forbid"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }
+
+[lib]
+name = "id_effect_rpc"
+
+[dependencies]
+axum = { version = "0.8", features = ["json"] }
+http = "1"
+id_effect = { path = "../id_effect", version = "0.2.0", features = [
+  "schema-serde",
+] }
+id_effect_axum = { path = "../id_effect_axum", version = "0.2.0" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+http-body-util = "0.1"
+rstest = "0.26"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tower = { version = "0.5", features = ["util"] }
+
+[[example]]
+name = "010_json_greet"
+path = "examples/010_json_greet.rs"

--- a/crates/id_effect_rpc/README.md
+++ b/crates/id_effect_rpc/README.md
@@ -1,0 +1,19 @@
+# `id_effect_rpc`
+
+Thin helpers for **RPC-shaped HTTP** boundaries when hosting `Effect` programs behind Axum:
+
+- **`RpcError`** — JSON envelope + status code + [`axum::response::IntoResponse`]
+- **Correlation ids** — read/propagate `x-correlation-id` (and optional generation)
+- **Tracing spans** — stable `rpc.request` span fields that compose with OpenTelemetry layers on the subscriber
+
+See the mdBook chapter [RPC boundaries with id_effect](../id_effect/book/src/part2/ch07-12-rpc-boundaries.md) (built with the `id_effect` book target).
+
+## Examples
+
+```bash
+cargo run -p id_effect_rpc --example 010_json_greet
+```
+
+## Phase D
+
+This crate implements **Phase D (stages D1–D2)** from `docs/effect-ts-parity/phases/phase-d-rpc.md`. Stage **D3** (codegen) remains optional backlog.

--- a/crates/id_effect_rpc/examples/010_json_greet.rs
+++ b/crates/id_effect_rpc/examples/010_json_greet.rs
@@ -1,0 +1,65 @@
+//! Axum JSON greet: validate body with [`id_effect::schema`] and return [`id_effect_rpc::RpcError`] on failure.
+//!
+//! Run (from repo root):
+//!
+//! ```bash
+//! cargo run -p id_effect_rpc --features examples --example 010_json_greet
+//! ```
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum::body::Bytes;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::post;
+use id_effect::schema;
+use id_effect_axum::json::decode_json_schema;
+use id_effect_rpc::RpcError;
+use id_effect_rpc::correlation::{append_correlation_header, ensure_correlation_id};
+use id_effect_rpc::span::{record_request_metadata, rpc_request_span};
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+async fn main() {
+  let greet_schema = Arc::new(schema::struct_(
+    "name",
+    schema::string::<()>(),
+    "enthusiasm",
+    schema::i64::<()>(),
+  ));
+
+  let schema = greet_schema.clone();
+  let app = Router::new().route(
+    "/greet",
+    post(
+      move |headers: axum::http::HeaderMap, body: Bytes| async move {
+        let cid = ensure_correlation_id(&headers);
+        let span = rpc_request_span();
+        let _enter = span.enter();
+        record_request_metadata(&span, Some(cid.as_str()), "POST", "/greet", "greet");
+
+        let (name, enthusiasm) = match decode_json_schema(schema.as_ref(), &body) {
+          Ok(v) => v,
+          Err(e) => return e.into_response(),
+        };
+
+        if enthusiasm < 0 {
+          let err = RpcError::invalid_argument("enthusiasm must be non-negative")
+            .with_correlation_id(cid.clone());
+          return err.into_response();
+        }
+
+        let msg = format!("Hello, {name}! ({enthusiasm}x)");
+        let mut res = (StatusCode::OK, msg).into_response();
+        append_correlation_header(res.headers_mut(), &cid);
+        res
+      },
+    ),
+  );
+
+  let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+  let addr = listener.local_addr().unwrap();
+  println!("Listening on http://{addr}/greet (POST JSON {{\"name\":\"Ada\",\"enthusiasm\":3}})");
+
+  axum::serve(listener, app).await.unwrap();
+}

--- a/crates/id_effect_rpc/moon.yml
+++ b/crates/id_effect_rpc/moon.yml
@@ -1,0 +1,88 @@
+# https://moonrepo.dev/docs/config/project
+language: 'rust'
+layer: 'library'
+tasks:
+  check:
+    deps: ['effect:ci-format', '^:check']
+    command:
+      - cargo
+      - check
+      - -p
+      - id_effect_rpc
+      - --all-targets
+      - --all-features
+    inputs:
+      - 'Cargo.toml'
+      - 'src/**/*.rs'
+      - 'tests/**/*.rs'
+      - 'examples/**/*.rs'
+    options:
+      cache: true
+      outputStyle: buffer-only-failure
+  clippy:
+    deps: ['^:clippy', '~:check']
+    command:
+      - cargo
+      - clippy
+      - -p
+      - id_effect_rpc
+      - --all-targets
+      - --all-features
+      - --
+      - -D
+      - warnings
+    inputs:
+      - 'Cargo.toml'
+      - 'src/**/*.rs'
+      - 'tests/**/*.rs'
+      - 'examples/**/*.rs'
+    options:
+      cache: true
+      outputStyle: buffer-only-failure
+  test:
+    deps: ['^:test', '~:clippy']
+    command:
+      - cargo
+      - nextest
+      - run
+      - -p
+      - id_effect_rpc
+    inputs:
+      - 'Cargo.toml'
+      - 'src/**/*.rs'
+      - 'tests/**/*.rs'
+      - 'examples/**/*.rs'
+    options:
+      cache: true
+      outputStyle: buffer-only-failure
+  build:
+    deps: ['^:build', '~:test']
+    command:
+      - cargo
+      - build
+      - -p
+      - id_effect_rpc
+      - --all-targets
+      - --all-features
+    inputs:
+      - 'Cargo.toml'
+      - 'src/**/*.rs'
+      - 'tests/**/*.rs'
+      - 'examples/**/*.rs'
+    options:
+      cache: true
+      outputStyle: buffer-only-failure
+  examples:
+    description: 'Build id_effect_rpc example binaries (requires features examples)'
+    deps: ['~:test']
+    command: 'bash'
+    args:
+      - '../../scripts/moon-run-crate-examples.sh'
+      - 'id_effect_rpc'
+    inputs:
+      - 'Cargo.toml'
+      - 'src/**/*.rs'
+      - 'examples/**/*.rs'
+    options:
+      cache: true
+      outputStyle: buffer-only-failure

--- a/crates/id_effect_rpc/src/correlation.rs
+++ b/crates/id_effect_rpc/src/correlation.rs
@@ -1,0 +1,123 @@
+//! Correlation id helpers for RPC-style HTTP (`x-correlation-id`).
+
+use axum::http::HeaderMap;
+use axum::http::header::HeaderName;
+
+/// Stable header name for request/response correlation (lowercase for intermediaries).
+pub static CORRELATION_ID_HEADER: HeaderName = HeaderName::from_static("x-correlation-id");
+
+/// Read correlation id from incoming headers when present and non-empty.
+#[inline]
+pub fn read_correlation_id(headers: &HeaderMap) -> Option<String> {
+  headers
+    .get(&CORRELATION_ID_HEADER)
+    .and_then(|v| v.to_str().ok())
+    .map(str::trim)
+    .filter(|s| !s.is_empty())
+    .map(str::to_owned)
+}
+
+/// Return existing correlation id or generate a new UUID v4 string.
+#[inline]
+pub fn ensure_correlation_id(headers: &HeaderMap) -> String {
+  read_correlation_id(headers).unwrap_or_else(|| uuid::Uuid::new_v4().to_string())
+}
+
+/// Append `x-correlation-id` to outgoing response headers (idempotent append).
+#[inline]
+pub fn append_correlation_header(headers: &mut HeaderMap, id: &str) {
+  if let Ok(v) = http::HeaderValue::from_str(id) {
+    headers.append(CORRELATION_ID_HEADER.clone(), v);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use axum::http::header::HeaderValue;
+
+  mod read_correlation_id {
+    use super::*;
+
+    #[test]
+    fn returns_none_when_header_absent() {
+      let h = HeaderMap::new();
+      assert!(read_correlation_id(&h).is_none());
+    }
+
+    #[test]
+    fn returns_trimmed_value_when_present() {
+      let mut h = HeaderMap::new();
+      h.insert(
+        CORRELATION_ID_HEADER.clone(),
+        HeaderValue::from_static("  abc-123  "),
+      );
+      assert_eq!(read_correlation_id(&h).as_deref(), Some("abc-123"));
+    }
+
+    #[test]
+    fn returns_none_when_empty_after_trim() {
+      let mut h = HeaderMap::new();
+      h.insert(
+        CORRELATION_ID_HEADER.clone(),
+        HeaderValue::from_static("   "),
+      );
+      assert!(read_correlation_id(&h).is_none());
+    }
+  }
+
+  mod ensure_correlation_id {
+    use super::*;
+
+    #[test]
+    fn preserves_existing_id() {
+      let mut h = HeaderMap::new();
+      h.insert(
+        CORRELATION_ID_HEADER.clone(),
+        HeaderValue::from_static("fixed"),
+      );
+      assert_eq!(ensure_correlation_id(&h), "fixed");
+    }
+
+    #[test]
+    fn generates_uuid_when_missing() {
+      let h = HeaderMap::new();
+      let id = ensure_correlation_id(&h);
+      assert_eq!(id.len(), 36);
+      assert!(uuid::Uuid::parse_str(&id).is_ok());
+    }
+  }
+
+  mod append_correlation_header {
+    use super::*;
+
+    #[test]
+    fn appends_valid_value() {
+      let mut h = HeaderMap::new();
+      append_correlation_header(&mut h, "out-1");
+      assert_eq!(
+        h.get(&CORRELATION_ID_HEADER).and_then(|v| v.to_str().ok()),
+        Some("out-1")
+      );
+    }
+  }
+
+  mod read_correlation_id_parameterized {
+    use super::*;
+    use axum::http::header::HeaderValue;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::plain_token("token-1", Some("token-1"))]
+    #[case::trimmed_inner("  spaced  ", Some("spaced"))]
+    fn returns_expected_correlation(
+      #[case] raw: &'static str,
+      #[case] expect: Option<&'static str>,
+    ) {
+      let mut h = HeaderMap::new();
+      let hv = HeaderValue::from_str(raw).expect("header value");
+      h.insert(CORRELATION_ID_HEADER.clone(), hv);
+      assert_eq!(read_correlation_id(&h).as_deref(), expect);
+    }
+  }
+}

--- a/crates/id_effect_rpc/src/envelope.rs
+++ b/crates/id_effect_rpc/src/envelope.rs
@@ -1,0 +1,94 @@
+//! JSON envelope for typed RPC-style failures at the HTTP boundary.
+
+use serde::{Deserialize, Serialize};
+
+/// Coarse error category for HTTP APIs (paired with an HTTP status in [`crate::RpcError`](crate::error::RpcError)).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RpcErrorCode {
+  /// Client sent malformed or semantically invalid input (typically 400).
+  InvalidArgument,
+  /// Resource does not exist (404).
+  NotFound,
+  /// Resource already exists (409).
+  AlreadyExists,
+  /// Missing or invalid credentials (401).
+  Unauthenticated,
+  /// Server-side failure (500).
+  Internal,
+}
+
+/// Wire body returned for structured RPC errors.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RpcEnvelope {
+  /// Machine-readable category.
+  pub code: RpcErrorCode,
+  /// Human-readable summary for operators and clients.
+  pub message: String,
+  /// Echoes `x-correlation-id` when one was present or generated at the edge.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub correlation_id: Option<String>,
+  /// Optional structured payload (validation details, etc.).
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub details: Option<serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use serde_json::json;
+
+  mod rpc_envelope {
+    use super::*;
+
+    mod round_trip_json {
+      use super::*;
+
+      #[test]
+      fn preserves_code_message_correlation_and_details() {
+        let env = RpcEnvelope {
+          code: RpcErrorCode::InvalidArgument,
+          message: "bad".to_owned(),
+          correlation_id: Some("cid-1".to_owned()),
+          details: Some(json!({"field": "age"})),
+        };
+        let bytes = serde_json::to_vec(&env).expect("serialize");
+        let back: RpcEnvelope = serde_json::from_slice(&bytes).expect("deserialize");
+        assert_eq!(back, env);
+      }
+
+      #[test]
+      fn omits_null_optional_fields_on_wire() {
+        let env = RpcEnvelope {
+          code: RpcErrorCode::Internal,
+          message: "x".to_owned(),
+          correlation_id: None,
+          details: None,
+        };
+        let v: serde_json::Value = serde_json::to_value(&env).expect("to_value");
+        assert!(v.get("correlation_id").is_none());
+        assert!(v.get("details").is_none());
+      }
+    }
+
+    mod rpc_error_code {
+      use super::*;
+
+      #[test]
+      fn serde_snake_case_round_trip() {
+        let codes = [
+          RpcErrorCode::InvalidArgument,
+          RpcErrorCode::NotFound,
+          RpcErrorCode::AlreadyExists,
+          RpcErrorCode::Unauthenticated,
+          RpcErrorCode::Internal,
+        ];
+        for code in codes {
+          let s = serde_json::to_string(&code).expect("ser");
+          let back: RpcErrorCode = serde_json::from_str(&s).expect("de");
+          assert_eq!(back, code);
+        }
+      }
+    }
+  }
+}

--- a/crates/id_effect_rpc/src/error.rs
+++ b/crates/id_effect_rpc/src/error.rs
@@ -1,0 +1,182 @@
+//! [`RpcError`] — structured JSON body + HTTP status + Axum [`IntoResponse`].
+
+use axum::Json;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+
+use crate::envelope::{RpcEnvelope, RpcErrorCode};
+
+/// Structured RPC failure for Axum handlers at the `Effect` boundary.
+#[derive(Debug, Clone)]
+pub struct RpcError {
+  status: StatusCode,
+  envelope: RpcEnvelope,
+}
+
+impl RpcError {
+  /// HTTP status returned to the client.
+  #[inline]
+  pub fn status(&self) -> StatusCode {
+    self.status
+  }
+
+  /// JSON envelope (clone for logging or tests).
+  #[inline]
+  pub fn envelope(&self) -> &RpcEnvelope {
+    &self.envelope
+  }
+
+  /// 400 — invalid client input.
+  #[inline]
+  pub fn invalid_argument(message: impl Into<String>) -> Self {
+    Self {
+      status: StatusCode::BAD_REQUEST,
+      envelope: RpcEnvelope {
+        code: RpcErrorCode::InvalidArgument,
+        message: message.into(),
+        correlation_id: None,
+        details: None,
+      },
+    }
+  }
+
+  /// 404 — resource missing.
+  #[inline]
+  pub fn not_found(message: impl Into<String>) -> Self {
+    Self {
+      status: StatusCode::NOT_FOUND,
+      envelope: RpcEnvelope {
+        code: RpcErrorCode::NotFound,
+        message: message.into(),
+        correlation_id: None,
+        details: None,
+      },
+    }
+  }
+
+  /// 409 — conflict / duplicate.
+  #[inline]
+  pub fn already_exists(message: impl Into<String>) -> Self {
+    Self {
+      status: StatusCode::CONFLICT,
+      envelope: RpcEnvelope {
+        code: RpcErrorCode::AlreadyExists,
+        message: message.into(),
+        correlation_id: None,
+        details: None,
+      },
+    }
+  }
+
+  /// 401 — missing or bad credentials.
+  #[inline]
+  pub fn unauthenticated(message: impl Into<String>) -> Self {
+    Self {
+      status: StatusCode::UNAUTHORIZED,
+      envelope: RpcEnvelope {
+        code: RpcErrorCode::Unauthenticated,
+        message: message.into(),
+        correlation_id: None,
+        details: None,
+      },
+    }
+  }
+
+  /// 500 — internal server error (do not leak secrets in `message`).
+  #[inline]
+  pub fn internal(message: impl Into<String>) -> Self {
+    Self {
+      status: StatusCode::INTERNAL_SERVER_ERROR,
+      envelope: RpcEnvelope {
+        code: RpcErrorCode::Internal,
+        message: message.into(),
+        correlation_id: None,
+        details: None,
+      },
+    }
+  }
+
+  /// Attach correlation id to the envelope (typically from [`crate::correlation`](crate::correlation)).
+  #[must_use]
+  #[inline]
+  pub fn with_correlation_id(mut self, id: impl Into<String>) -> Self {
+    self.envelope.correlation_id = Some(id.into());
+    self
+  }
+
+  /// Attach structured details (e.g. validation errors).
+  #[must_use]
+  #[inline]
+  pub fn with_details(mut self, details: serde_json::Value) -> Self {
+    self.envelope.details = Some(details);
+    self
+  }
+}
+
+impl IntoResponse for RpcError {
+  fn into_response(self) -> Response {
+    (self.status, Json(self.envelope)).into_response()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use http_body_util::BodyExt;
+  use serde_json::json;
+
+  mod rpc_error {
+    use super::*;
+
+    mod into_response {
+      use super::*;
+
+      #[tokio::test]
+      async fn not_found_returns_404_json_envelope() {
+        let err = RpcError::not_found("nope").with_correlation_id("abc");
+        let res = err.into_response();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+        let body = res.into_body();
+        let bytes = body.collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["code"], "not_found");
+        assert_eq!(v["message"], "nope");
+        assert_eq!(v["correlation_id"], "abc");
+      }
+
+      #[tokio::test]
+      async fn internal_round_trip_envelope_matches_status() {
+        let err = RpcError::internal("boom").with_details(json!({"hint": "retry"}));
+        let res = err.clone().into_response();
+        assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = res.into_body();
+        let bytes = body.collect().await.unwrap().to_bytes();
+        let env: RpcEnvelope = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(env, *err.envelope());
+      }
+    }
+
+    mod status_mapping {
+      use super::*;
+
+      #[test]
+      fn invalid_argument_is_bad_request() {
+        let e = RpcError::invalid_argument("x");
+        assert_eq!(e.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(e.envelope().code, RpcErrorCode::InvalidArgument);
+      }
+
+      #[test]
+      fn unauthenticated_is_unauthorized() {
+        let e = RpcError::unauthenticated("no token");
+        assert_eq!(e.status(), StatusCode::UNAUTHORIZED);
+      }
+
+      #[test]
+      fn already_exists_is_conflict() {
+        let e = RpcError::already_exists("dup");
+        assert_eq!(e.status(), StatusCode::CONFLICT);
+      }
+    }
+  }
+}

--- a/crates/id_effect_rpc/src/error.rs
+++ b/crates/id_effect_rpc/src/error.rs
@@ -96,7 +96,7 @@ impl RpcError {
     }
   }
 
-  /// Attach correlation id to the envelope (typically from [`crate::correlation`](crate::correlation)).
+  /// Attach correlation id to the envelope (typically from [`crate::correlation`]).
   #[must_use]
   #[inline]
   pub fn with_correlation_id(mut self, id: impl Into<String>) -> Self {

--- a/crates/id_effect_rpc/src/lib.rs
+++ b/crates/id_effect_rpc/src/lib.rs
@@ -1,0 +1,27 @@
+//! RPC-style HTTP helpers for [`id_effect`](https://docs.rs/id_effect) Axum hosts — **Phase D**
+//! (`@effect/rpc`-shaped boundaries).
+//!
+//! ## Contents
+//!
+//! - [`RpcError`] — JSON envelope + status + [`IntoResponse`](axum::response::IntoResponse)
+//! - [`correlation`] — `x-correlation-id` propagation
+//! - [`span`] — `tracing` span helpers compatible with OpenTelemetry layers
+//!
+//! Pair with **`id_effect_axum::json`** (`decode_json_schema`, `JsonSchemaError`) for
+//! schema-validated JSON bodies at the wire edge (see the mdBook *Axum host* chapter).
+//!
+//! ## Book
+//!
+//! See the mdBook chapter *RPC boundaries with id_effect* (`ch07-12-rpc-boundaries.md`).
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+#![allow(clippy::missing_panics_doc)]
+
+pub mod correlation;
+mod envelope;
+pub mod error;
+pub mod span;
+
+pub use envelope::{RpcEnvelope, RpcErrorCode};
+pub use error::RpcError;

--- a/crates/id_effect_rpc/src/span.rs
+++ b/crates/id_effect_rpc/src/span.rs
@@ -1,0 +1,58 @@
+//! Tracing helpers for RPC-shaped HTTP handlers.
+//!
+//! Spans use stable field names so an OpenTelemetry layer on the subscriber can map them to
+//! semantic conventions without this crate depending on OTEL crates directly.
+
+use tracing::Span;
+
+/// Root span for one RPC-style HTTP request. Record metadata with [`record_request_metadata`].
+#[inline]
+pub fn rpc_request_span() -> Span {
+  tracing::info_span!(
+    "rpc.request",
+    correlation.id = tracing::field::Empty,
+    http.method = tracing::field::Empty,
+    http.route = tracing::field::Empty,
+    rpc.operation = tracing::field::Empty,
+  )
+}
+
+/// Fill standard RPC span fields (safe for high-cardinality: avoid raw URLs with query tokens).
+#[inline]
+pub fn record_request_metadata(
+  span: &Span,
+  correlation_id: Option<&str>,
+  method: &str,
+  route: &str,
+  operation: &str,
+) {
+  if let Some(c) = correlation_id {
+    span.record("correlation.id", c);
+  }
+  span.record("http.method", method);
+  span.record("http.route", route);
+  span.record("rpc.operation", operation);
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  mod rpc_request_span {
+    use super::*;
+
+    #[test]
+    fn constructs_without_panicking() {
+      let span = rpc_request_span();
+      let _g = span.enter();
+      record_request_metadata(&span, Some("c1"), "POST", "/greet", "greet");
+    }
+
+    #[test]
+    fn allows_missing_correlation_id() {
+      let span = rpc_request_span();
+      let _g = span.enter();
+      record_request_metadata(&span, None, "GET", "/health", "health");
+    }
+  }
+}

--- a/crates/id_effect_rpc/tests/wire_round_trip.rs
+++ b/crates/id_effect_rpc/tests/wire_round_trip.rs
@@ -1,0 +1,26 @@
+//! Integration-style wire tests: Axum + [`id_effect_rpc::RpcError`] JSON body.
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::routing::get;
+use http_body_util::BodyExt;
+use id_effect_rpc::RpcError;
+use tower::ServiceExt;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rpc_error_unauthenticated_round_trips_json_fields() {
+  let app = Router::new().route(
+    "/x",
+    get(|| async move { RpcError::unauthenticated("missing bearer").with_correlation_id("z9") }),
+  );
+
+  let req = Request::builder().uri("/x").body(Body::empty()).unwrap();
+  let res = app.oneshot(req).await.unwrap();
+  assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+  let bytes = res.into_body().collect().await.unwrap().to_bytes();
+  let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+  assert_eq!(v["code"], "unauthenticated");
+  assert_eq!(v["message"], "missing bearer");
+  assert_eq!(v["correlation_id"], "z9");
+}

--- a/docs/effect-ts-parity/phases/phase-d-rpc.md
+++ b/docs/effect-ts-parity/phases/phase-d-rpc.md
@@ -4,6 +4,8 @@
 **Effect.ts reference:** `@effect/rpc` — schemas, request/response contracts, protocol handlers.  
 **Goal:** Document and optionally implement **RPC-style** communication where **`Effect`**, **`R`**, and **errors** cross process boundaries in a disciplined way—starting with **patterns** on top of existing Rust stacks, evolving toward **codegen** if justified.
 
+**Implementation status (workspace):** Stages **D1** (mdBook + comparison + Axum JSON example) and **D2** (`id_effect_rpc` crate: `RpcError`, correlation ids, tracing span helpers, tests) are implemented in-tree. Stage **D3** (codegen) remains optional backlog (`iep-d-030` / `iep-d-031`).
+
 ## Executive summary
 
 Effect.ts RPC ties **Schema**, **Layer**, and **platform HTTP** together. In Rust, the nearest ecosystem is **`tonic` + `prost`**, **`tarpc`**, or custom HTTP+JSON. Phase D is intentionally **staged**:


### PR DESCRIPTION
Add id_effect_rpc with RpcError JSON envelope, x-correlation-id helpers, tracing span metadata, Axum example, and tests per TESTING.md. Document D1 patterns in the book; note D1-D2 status in phase-d-rpc.md.