### PR TITLE
feat(cli): Phase E CLI parity (id_effect_cli + mdBook + cli_minimal)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,7 @@ jobs:
             crates/id_effect_proc_macro/Cargo.toml
             crates/id_effect_macro/Cargo.toml
             crates/id_effect/Cargo.toml
+            crates/id_effect_cli/Cargo.toml
             crates/id_effect_tokio/Cargo.toml
             crates/id_effect_logger/Cargo.toml
             crates/id_effect_config/Cargo.toml
@@ -139,6 +140,15 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           args=(--package id_effect --no-verify)
+          [ "${{ inputs.dry_run }}" = "true" ] && args+=(--dry-run)
+          cargo publish "${args[@]}"
+      - name: Wait for crates.io index
+        run: sleep 20
+      - name: Publish id_effect_cli
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          args=(--package id_effect_cli --no-verify)
           [ "${{ inputs.dry_run }}" = "true" ] && args+=(--dry-run)
           cargo publish "${args[@]}"
   # ──────────────────────────────────────────────────────────────────────────

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -1,8 +1,10 @@
 # https://moonrepo.dev/docs/config/workspace
 $schema: https://moonrepo.dev/schemas/workspace.json
 projects:
+  cli_minimal: examples/cli-minimal
   effect: '.'
   id_effect_lib: crates/id_effect
+  id_effect_cli: crates/id_effect_cli
   id_effect_platform: crates/id_effect_platform
   id_effect_axum: crates/id_effect_axum
   id_effect_config: crates/id_effect_config

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 exclude = [".tmp", "tmp", "crates/id_effect_lint"]
 members = [
   "crates/id_effect",
+  "crates/id_effect_cli",
   "crates/id_effect_platform",
   "crates/id_effect_axum",
   "crates/id_effect_config",
@@ -12,6 +13,7 @@ members = [
   "crates/id_effect_reqwest",
   "crates/id_effect_tokio",
   "crates/id_effect_tower",
+  "examples/cli-minimal",
 ]
 
 # More stable / comparable Criterion numbers than default bench profile (inherits release).

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ For depth beyond this README, use the mdBook [**Typed Effects in Rust**](https:/
 | [`id_effect_axum`](crates/id_effect_axum) | [![crates.io](https://img.shields.io/crates/v/id_effect_axum.svg)](https://crates.io/crates/id_effect_axum) | Axum integration |
 | [`id_effect_logger`](crates/id_effect_logger) | [![crates.io](https://img.shields.io/crates/v/id_effect_logger.svg)](https://crates.io/crates/id_effect_logger) | Logging service (tracing backend) |
 | [`id_effect_config`](crates/id_effect_config) | [![crates.io](https://img.shields.io/crates/v/id_effect_config.svg)](https://crates.io/crates/id_effect_config) | `ConfigProvider` + Figment/serde layers |
+| [`id_effect_cli`](crates/id_effect_cli) | [![crates.io](https://img.shields.io/crates/v/id_effect_cli.svg)](https://crates.io/crates/id_effect_cli) | CLI edge: `run_main`, `Exit` / `Cause` → `ExitCode`, optional `clap` ([book](https://industrial.github.io/id_effect/part3/ch16-00-cli-with-clap.html)) |
 | [`id_effect_platform`](crates/id_effect_platform) | (publish with core) | Platform traits: HTTP, FS, process (`@effect/platform` parity) |
 | [`id_effect_reqwest`](crates/id_effect_reqwest) | [![crates.io](https://img.shields.io/crates/v/id_effect_reqwest.svg)](https://crates.io/crates/id_effect_reqwest) | HTTP via reqwest |
 | [`id_effect_tower`](crates/id_effect_tower) | [![crates.io](https://img.shields.io/crates/v/id_effect_tower.svg)](https://crates.io/crates/id_effect_tower) | Tower `Service` bridge |
@@ -79,12 +80,18 @@ fn greet(name: &str) -> Effect<String, (), ()> {
 }
 
 fn main() {
-    let result = greet("world").run_sync(());
+    let result = id_effect::run_blocking(greet("world"), ());
     println!("{result:?}");
 }
 ```
 
 For a guided path through the API, read [**Typed Effects in Rust**](https://industrial.github.io/id_effect/) first, then use the numbered examples under [`crates/id_effect/examples/`](crates/id_effect/examples/) and [docs.rs](https://docs.rs/id_effect).
+
+**CLI template:** [`examples/cli-minimal/`](examples/cli-minimal/) shows `clap` + [`id_effect_cli`](crates/id_effect_cli) + [`id_effect_config`](crates/id_effect_config) (`Secret`). Run:
+
+```bash
+devenv shell -- cargo run -p cli_minimal -- --token dummy
+```
 
 ---
 
@@ -93,6 +100,7 @@ For a guided path through the API, read [**Typed Effects in Rust**](https://indu
 | Resource | Link |
 |----------|------|
 | **Book (primary learning path)** | [**Typed Effects in Rust**](https://industrial.github.io/id_effect/) — [glossary](https://industrial.github.io/id_effect/appendix-c-glossary.html) |
+| **CLI with `clap` + `ExitCode`** | [CLI with clap (`id_effect_cli`)](https://industrial.github.io/id_effect/part3/ch16-00-cli-with-clap.html) |
 | API reference | [docs.rs/id_effect](https://docs.rs/id_effect) |
 | Examples | [`crates/id_effect/examples/`](crates/id_effect/examples/) |
 

--- a/crates/id_effect/book/src/SUMMARY.md
+++ b/crates/id_effect/book/src/SUMMARY.md
@@ -73,6 +73,9 @@
   - [Built-in Schedules](./part3/ch11-02-builtin-schedules.md)
   - [retry and repeat](./part3/ch11-03-retry-repeat.md)
   - [Clock Injection](./part3/ch11-04-clock-injection.md)
+- [CLI with clap](./part3/ch16-00-cli-with-clap.md)
+  - [Exit codes for `main`](./part3/ch16-01-cli-exit-codes.md)
+  - [Config + `Secret` from flags](./part3/ch16-02-cli-config-secret.md)
 
 # Part IV: Advanced
 

--- a/crates/id_effect/book/src/appendix-c-glossary.md
+++ b/crates/id_effect/book/src/appendix-c-glossary.md
@@ -89,6 +89,11 @@ Workspace crate bridging **Axum** handlers to **`Effect`**: `State<R>`, `routing
 
 ---
 
+**`id_effect_cli`**
+Workspace crate for **CLI entrypoints**: optional **`clap`**, [`run_main`](./part3/ch16-00-cli-with-clap.md), and mapping [`Exit`](./part3/ch08-02-exit.md) / [`Cause`](./part3/ch08-02-exit.md) to process exit codes. See [CLI with clap](./part3/ch16-00-cli-with-clap.md).
+
+---
+
 **`id_effect_config`**
 Workspace crate for **configuration**: `Config<T>` descriptors, Figment/serde extraction, and effectful reads from a provider in `R`. See [Configuration](./part2/ch07-10-config.md).
 

--- a/crates/id_effect/book/src/part3/ch08-02-exit.md
+++ b/crates/id_effect/book/src/part3/ch08-02-exit.md
@@ -7,30 +7,18 @@ Every effect execution ends with an `Exit`. It's the final word on what happened
 ```rust
 use id_effect::Exit;
 
-enum Exit<E, A> {
+enum Exit<A, E> {
     Success(A),         // Effect completed, produced A
     Failure(Cause<E>),  // Effect failed with Cause<E>
 }
 ```
 
-`Exit` combines the success type and the full failure taxonomy. It's what you get when you use `run_to_exit` instead of `run_blocking`:
+`Exit` combines the success type and the full failure taxonomy.
 
-```rust
-use id_effect::run_to_exit;
+- **`run_blocking`** returns **`Result<A, E>`** — you only see typed **`E`** failures; defects and interrupts are not represented as values there.
+- [`run_test`](../part4/ch15-01-run-test.md) returns **`Exit<A, E>`** and is the right harness for **unit tests** that must assert on defects, interrupts, and typed failures.
 
-// run_blocking returns Result<A, E> — loses Cause::Die and Cause::Interrupt info
-let user: Result<User, DbError> = run_blocking(get_user(1))?;
-
-// run_to_exit returns Exit<E, A> — full picture
-let exit: Exit<DbError, User> = run_to_exit(get_user(1));
-
-match exit {
-    Exit::Success(user)                    => println!("Got user: {}", user.name),
-    Exit::Failure(Cause::Fail(DbError::NotFound)) => println!("User not found"),
-    Exit::Failure(Cause::Die(panic_val))   => eprintln!("Defect: {:?}", panic_val),
-    Exit::Failure(Cause::Interrupt)        => println!("Cancelled"),
-}
-```
+For **CLI / process exit codes**, map an `Exit` with **`id_effect_cli::exit_code_for_exit`** (see [CLI with clap](./ch16-00-cli-with-clap.md)).
 
 ## Converting Exit to Result
 
@@ -40,7 +28,7 @@ Most application code wants `Result`. The conversion is straightforward:
 let result: Result<User, AppError> = exit.into_result(|cause| match cause {
     Cause::Fail(e) => AppError::Expected(e),
     Cause::Die(_)  => AppError::Defect,
-    Cause::Interrupt => AppError::Cancelled,
+    Cause::Interrupt(_) => AppError::Cancelled,
 });
 ```
 
@@ -56,11 +44,11 @@ When you join a fiber (Chapter 9), you get an `Exit` back:
 
 ```rust
 let fiber = my_effect.fork();
-let exit: Exit<E, A> = fiber.join().await;
+let exit: Exit<A, E> = fiber.join().await;
 ```
 
 This lets you inspect whether the fiber succeeded, failed with a typed error, panicked, or was cancelled — and respond appropriately in the parent fiber.
 
 ## Practical Rule
 
-Use `run_blocking` (which returns `Result<A, E>`) for 90% of cases. Use `run_to_exit` when you need to distinguish panics from typed failures — typically at top-level handlers, supervisors, or when integrating with external error reporting.
+Use **`run_blocking`** (which returns **`Result<A, E>`**) for most application logic. Use **`run_test`** when you need the full **`Exit`** taxonomy in tests. At the **process edge** (binaries), combine **`run_main`** / **`exit_code_for_exit`** from **`id_effect_cli`** with the table in the [CLI exit codes](./ch16-01-cli-exit-codes.md) chapter.

--- a/crates/id_effect/book/src/part3/ch16-00-cli-with-clap.md
+++ b/crates/id_effect/book/src/part3/ch16-00-cli-with-clap.md
@@ -1,0 +1,52 @@
+# CLI entrypoints with `clap` + `Effect`
+
+Rust’s standard answer for parsing is **[`clap`](https://docs.rs/clap)**. For **id_effect**, treat the binary as a **thin shell**:
+
+1. **Parse** argv into a struct (`#[derive(clap::Parser)]`).
+2. **Assemble** layers / `MapConfigProvider` / other `R` values from flags and environment.
+3. **Run** your program `Effect<A, E, R>` with [`run_blocking`](https://docs.rs/id_effect/latest/id_effect/runtime/fn.run_blocking.html) (or an async driver when you integrate Tokio).
+4. **Exit** with [`std::process::ExitCode`] using [`id_effect_cli`](https://docs.rs/id_effect_cli) helpers (see the next sections).
+
+This mirrors Effect.ts **`@effect/cli`**: declarative argument models composed into a single program — here the “program” is an `Effect` value rather than a `Future` chain.
+
+## Recommended `main` shape (Rust 1.61+)
+
+Returning [`ExitCode`](https://doc.rust-lang.org/std/process/struct.ExitCode.html) keeps `main` testable and avoids calling [`std::process::exit`](https://doc.rust-lang.org/std/process/fn.exit.html) deep inside library code:
+
+```rust
+use clap::Parser;
+use id_effect_cli::{run_main, RunMainConfig};
+
+#[derive(Parser)]
+struct Cli {
+    #[arg(long)]
+    name: String,
+}
+
+fn main() -> std::process::ExitCode {
+    let cli = Cli::parse();
+    let eff = my_app(cli.name);
+    run_main(eff, my_env(), RunMainConfig::with_tracing())
+}
+```
+
+`my_app` returns an `Effect<…>`; `my_env()` is whatever `R` your effect needs (often a [`Context`](https://docs.rs/id_effect/latest/id_effect/context/struct.Context.html) built from [`Layer`](https://docs.rs/id_effect/latest/id_effect/layer/struct.Layer.html) stacks).
+
+## Workspace helpers
+
+The **`id_effect_cli`** crate (same repository) provides:
+
+- Optional **`clap`** dependency (feature flag; on by default for convenience).
+- [`run_main`](https://docs.rs/id_effect_cli/latest/id_effect_cli/fn.run_main.html) — optional tracing install, [`run_blocking`](https://docs.rs/id_effect/latest/id_effect/runtime/fn.run_blocking.html), stderr logging for `Err`, [`ExitCode`](https://doc.rust-lang.org/std/process/struct.ExitCode.html) mapping.
+- [`exit_code_for_exit`](https://docs.rs/id_effect_cli/latest/id_effect_cli/fn.exit_code_for_exit.html) / [`exit_code_for_cause`](https://docs.rs/id_effect_cli/latest/id_effect_cli/fn.exit_code_for_cause.html) when you already have an [`Exit`](https://docs.rs/id_effect/latest/id_effect/enum.Exit.html) from [`run_test`](https://docs.rs/id_effect/latest/id_effect/fn.run_test.html) or a supervisor.
+
+## Template
+
+See the checked-in example **[`examples/cli-minimal`](https://github.com/Industrial/id_effect/tree/main/examples/cli-minimal)** (`--token …`, `Secret` via [`id_effect_config`](../part2/ch07-10-config.md)).
+
+## Further reading
+
+- [Exit codes for `main`](./ch16-01-cli-exit-codes.md) — `Exit` / `Cause` → `ExitCode` table
+- [Config + `Secret` from flags](./ch16-02-cli-config-secret.md) — wiring `id_effect_config` at the edge
+- [Error handling](./ch08-00-error-handling.md) — [`Cause`](https://docs.rs/id_effect/latest/id_effect/enum.Cause.html) vs plain `E`
+- [Configuration (`id_effect_config`)](../part2/ch07-10-config.md)

--- a/crates/id_effect/book/src/part3/ch16-01-cli-exit-codes.md
+++ b/crates/id_effect/book/src/part3/ch16-01-cli-exit-codes.md
@@ -1,0 +1,36 @@
+# Exit codes for `main`
+
+When a CLI finishes, the OS only sees an **8-bit exit status**. **id_effect** distinguishes richer outcomes ([`Exit`](https://docs.rs/id_effect/latest/id_effect/enum.Exit.html), [`Cause`](https://docs.rs/id_effect/latest/id_effect/enum.Cause.html)); at the process edge you collapse that into [`std::process::ExitCode`](https://doc.rust-lang.org/std/process/struct.ExitCode.html).
+
+## `Result` from `run_blocking`
+
+[`run_blocking`](https://docs.rs/id_effect/latest/id_effect/runtime/fn.run_blocking.html) returns `Result<A, E>`:
+
+| Outcome | Suggested CLI byte | Notes |
+|---------|-------------------|--------|
+| `Ok(_)` | `0` | success |
+| `Err(_)` | `1` | typed / expected failure ([`id_effect_cli::exit_code_for_result`](https://docs.rs/id_effect_cli/latest/id_effect_cli/fn.exit_code_for_result.html)) |
+
+[`id_effect_cli::run_main`](https://docs.rs/id_effect_cli/latest/id_effect_cli/fn.run_main.html) uses this mapping and prints `Err` with `Debug` to **stderr**.
+
+## Full `Exit` / `Cause`
+
+When you have an [`Exit`](https://docs.rs/id_effect/latest/id_effect/enum.Exit.html) (for example from tests or a custom driver), map **leaf** causes as follows — composite [`Cause::Both`](https://docs.rs/id_effect/latest/id_effect/enum.Cause.html#variant.Both) / [`Cause::Then`](https://docs.rs/id_effect/latest/id_effect/enum.Cause.html#variant.Then) use the **maximum** byte so “stronger” failures dominate:
+
+| Pattern | Byte | Meaning |
+|---------|------|---------|
+| [`Exit::Success`](https://docs.rs/id_effect/latest/id_effect/enum.Exit.html#variant.Success) | `0` | OK |
+| [`Cause::Fail`](https://docs.rs/id_effect/latest/id_effect/enum.Cause.html#variant.Fail)(_) | `1` | expected typed failure |
+| [`Cause::Die`](https://docs.rs/id_effect/latest/id_effect/enum.Cause.html#variant.Die)(_) | `101` | defect (panic-style message) |
+| [`Cause::Interrupt`](https://docs.rs/id_effect/latest/id_effect/enum.Cause.html#variant.Interrupt)(_) | `130` | cancellation (same convention many shells use for **SIGINT**) |
+| [`Cause::Both`](https://docs.rs/id_effect/latest/id_effect/enum.Cause.html#variant.Both) / [`Cause::Then`](https://docs.rs/id_effect/latest/id_effect/enum.Cause.html#variant.Then) | `max(left, right)` | recurse |
+
+Helpers: [`exit_code_for_exit`](https://docs.rs/id_effect_cli/latest/id_effect_cli/fn.exit_code_for_exit.html), [`exit_code_for_cause`](https://docs.rs/id_effect_cli/latest/id_effect_cli/fn.exit_code_for_cause.html), [`cause_max_exit_byte`](https://docs.rs/id_effect_cli/latest/id_effect_cli/fn.cause_max_exit_byte.html).
+
+## Practical guidance
+
+- Use **`1`** for “the command could not complete successfully” (missing flag, validation error, upstream HTTP 4xx mapped to your `E`, …).
+- Reserve **`101`** for “the program detected an internal defect” — corresponds to [`Cause::Die`](https://docs.rs/id_effect/latest/id_effect/enum.Cause.html#variant.Die) in structured runs (see [`cause_max_exit_byte`](https://docs.rs/id_effect_cli/latest/id_effect_cli/fn.cause_max_exit_byte.html)).
+- Use **`130`** only when you surface fiber **interruption** to the process edge (rare in simple CLIs).
+
+If you need richer machine output, prefer **stderr JSON** or a dedicated output file — do not overload exit codes beyond what your operators can act on.

--- a/crates/id_effect/book/src/part3/ch16-02-cli-config-secret.md
+++ b/crates/id_effect/book/src/part3/ch16-02-cli-config-secret.md
@@ -1,0 +1,31 @@
+# Config + `Secret` from flags
+
+[`id_effect_config`](../part2/ch07-10-config.md) already documents providers and [`Config`](https://docs.rs/id_effect_config/latest/id_effect_config/struct.Config.html) descriptors. At a **CLI edge**, you usually:
+
+1. **Parse** a `--token` / `--api-key` flag (or read a path to a file).
+2. **Seed** a [`MapConfigProvider`](https://docs.rs/id_effect_config/latest/id_effect_config/struct.MapConfigProvider.html) (or `EnvConfigProvider`) so the key matches what your `Config::*` descriptors expect.
+3. **Evaluate** `Config::…` inside an `Effect` using [`config_env`](https://docs.rs/id_effect_config/latest/id_effect_config/fn.config_env.html) in `R`.
+4. **Wrap** sensitive strings with [`Secret`](https://docs.rs/id_effect_config/latest/id_effect_config/struct.Secret.html) via [`Config::secret`](https://docs.rs/id_effect_config/latest/id_effect_config/struct.Config.html#method.secret) so logs and `Debug` never print raw material.
+
+## Minimal snippet
+
+```rust
+use id_effect::Effect;
+use id_effect_config::{
+    Config, ConfigError, MapConfigProvider, Secret, config_env,
+};
+
+fn load_api_token() -> Effect<Secret<String>, ConfigError, id_effect_config::ConfigEnv> {
+    Config::string("API_TOKEN").secret().run::<Secret<String>, ConfigError, _>()
+}
+
+// In main: build provider from CLI flag, then `config_env(provider)` and `run_blocking`.
+```
+
+The repository ships a full runnable layout under **[`examples/cli-minimal`](https://github.com/Industrial/id_effect/tree/main/examples/cli-minimal)** (`cli_minimal` package in the workspace).
+
+## Operational notes
+
+- Prefer **short-lived** exposure of secrets: parse → wrap in [`Secret`](https://docs.rs/id_effect_config/latest/id_effect_config/struct.Secret.html) → pass to effects; avoid storing raw `String` copies in globals.
+- For file-based secrets, read bytes in an effect and wrap immediately; redact paths in error messages if they reveal usernames.
+- Combine with [CLI with clap](./ch16-00-cli-with-clap.md) for argv parsing and [exit codes](./ch16-01-cli-exit-codes.md) for `main`.

--- a/crates/id_effect_cli/Cargo.toml
+++ b/crates/id_effect_cli/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "id_effect_cli"
+version = "0.2.0"
+edition = "2024"
+license = "CC-BY-SA-4.0"
+description = "CLI helpers for id_effect: optional clap, Exit/Cause → ExitCode, tracing init, run_main"
+repository = "https://github.com/Industrial/id_effect"
+readme = "README.md"
+
+[lints.rust]
+unsafe_code = "forbid"
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(coverage)',
+  'cfg(feature, values("mock", "clap"))',
+] }
+
+[features]
+default = ["clap"]
+clap = ["dep:clap"]
+
+[dependencies]
+id_effect = { path = "../id_effect", version = "0.2.0" }
+clap = { version = "4.5", optional = true, default-features = false, features = [
+  "std",
+  "derive",
+  "help",
+  "usage",
+  "error-context",
+] }
+
+[dev-dependencies]
+rstest = "0.26"
+
+[[bin]]
+name = "ie_cli_probe"
+path = "src/bin/ie_cli_probe.rs"
+required-features = ["clap"]

--- a/crates/id_effect_cli/README.md
+++ b/crates/id_effect_cli/README.md
@@ -1,0 +1,9 @@
+# `id_effect_cli`
+
+Thin helpers for building **CLIs whose bodies are [`Effect`](https://docs.rs/id_effect/latest/id_effect/kernel/struct.Effect.html) programs**, aligned with [Phase E — CLI ergonomics](../../docs/effect-ts-parity/phases/phase-e-cli.md):
+
+- Map [`Exit`](https://docs.rs/id_effect/latest/id_effect/enum.Exit.html) / [`Cause`](https://docs.rs/id_effect/latest/id_effect/enum.Cause.html) to [`std::process::ExitCode`].
+- Optional [`clap`](https://docs.rs/clap) (feature `clap`, on by default).
+- [`run_main`](https://docs.rs/id_effect_cli/latest/id_effect_cli/fn.run_main.html) — optional tracing install via [`install_tracing_layer`](https://docs.rs/id_effect/latest/id_effect/fn.install_tracing_layer.html), then [`run_blocking`](https://docs.rs/id_effect/latest/id_effect/runtime/fn.run_blocking.html), then stderr logging and exit code mapping.
+
+See the mdBook chapter **CLI entrypoints (`id_effect_cli`)** under *Part II → Services*, the [`examples/cli-minimal`](../../examples/cli-minimal/) template, and crate docs on [docs.rs](https://docs.rs/id_effect_cli).

--- a/crates/id_effect_cli/moon.yml
+++ b/crates/id_effect_cli/moon.yml
@@ -1,0 +1,70 @@
+# https://moonrepo.dev/docs/config/project
+language: 'rust'
+layer: 'library'
+tasks:
+  check:
+    deps: ['effect:ci-format', '^:check']
+    command:
+      - cargo
+      - check
+      - -p
+      - id_effect_cli
+      - --all-targets
+      - --all-features
+    inputs:
+      - 'Cargo.toml'
+      - 'src/**/*.rs'
+      - 'tests/**/*.rs'
+    options:
+      cache: true
+      outputStyle: buffer-only-failure
+  clippy:
+    deps: ['^:clippy', '~:check']
+    command:
+      - cargo
+      - clippy
+      - -p
+      - id_effect_cli
+      - --all-targets
+      - --all-features
+      - --
+      - -D
+      - warnings
+    inputs:
+      - 'Cargo.toml'
+      - 'src/**/*.rs'
+      - 'tests/**/*.rs'
+    options:
+      cache: true
+      outputStyle: buffer-only-failure
+  test:
+    deps: ['^:test', '~:clippy']
+    command:
+      - cargo
+      - nextest
+      - run
+      - -p
+      - id_effect_cli
+    inputs:
+      - 'Cargo.toml'
+      - 'src/**/*.rs'
+      - 'tests/**/*.rs'
+    options:
+      cache: true
+      outputStyle: buffer-only-failure
+  build:
+    deps: ['^:build', '~:test']
+    command:
+      - cargo
+      - build
+      - -p
+      - id_effect_cli
+      - --all-targets
+      - --all-features
+    inputs:
+      - 'Cargo.toml'
+      - 'src/**/*.rs'
+      - 'tests/**/*.rs'
+    options:
+      cache: true
+      outputStyle: buffer-only-failure

--- a/crates/id_effect_cli/src/bin/ie_cli_probe.rs
+++ b/crates/id_effect_cli/src/bin/ie_cli_probe.rs
@@ -1,0 +1,28 @@
+//! Tiny probe binary for integration tests (exit `0` / `1`).
+
+use clap::{Parser, ValueEnum};
+use id_effect::{Effect, fail, succeed};
+use std::process::ExitCode;
+
+#[derive(Parser, Debug)]
+#[command(name = "ie_cli_probe")]
+struct Args {
+  /// Whether the embedded effect succeeds or fails.
+  #[arg(long, value_enum)]
+  mode: ProbeMode,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum ProbeMode {
+  Ok,
+  Fail,
+}
+
+fn main() -> ExitCode {
+  let args = Args::parse();
+  let eff: Effect<(), String, ()> = match args.mode {
+    ProbeMode::Ok => succeed(()),
+    ProbeMode::Fail => fail("boom".into()),
+  };
+  id_effect_cli::run_main(eff, (), id_effect_cli::RunMainConfig::minimal())
+}

--- a/crates/id_effect_cli/src/exit_code.rs
+++ b/crates/id_effect_cli/src/exit_code.rs
@@ -1,0 +1,132 @@
+//! Map [`id_effect::Exit`], [`id_effect::Cause`], and [`Result`] to [`std::process::ExitCode`].
+
+use id_effect::{Cause, Exit};
+use std::process::ExitCode;
+
+/// Numeric byte used inside [`ExitCode`] for a [`Cause`] tree (deepest / worst wins for composites).
+///
+/// Convention (documented in the mdBook *CLI exit codes* chapter):
+///
+/// | Kind | Byte | Meaning |
+/// |------|------|---------|
+/// | success (`Exit::Success`) | `0` | OK |
+/// | [`Cause::Fail`] | `1` | expected / typed failure |
+/// | [`Cause::Die`] | `101` | defect (panic-style) |
+/// | [`Cause::Interrupt`] | `130` | cancellation (shell SIGINT convention) |
+/// | [`Cause::Both`] / [`Cause::Then`] | `max(left, right)` | preserve strongest signal |
+pub fn cause_max_exit_byte<E>(cause: &Cause<E>) -> u8 {
+  match cause {
+    Cause::Fail(_) => 1,
+    Cause::Die(_) => 101,
+    Cause::Interrupt(_) => 130,
+    Cause::Both(l, r) | Cause::Then(l, r) => cause_max_exit_byte(l).max(cause_max_exit_byte(r)),
+  }
+}
+
+/// [`ExitCode`] for a finished [`Exit`] value.
+#[inline]
+pub fn exit_code_for_exit<A, E>(exit: Exit<A, E>) -> ExitCode {
+  match exit {
+    Exit::Success(_) => ExitCode::SUCCESS,
+    Exit::Failure(cause) => exit_code_for_cause(cause),
+  }
+}
+
+/// [`ExitCode`] from a structured [`Cause`].
+#[inline]
+pub fn exit_code_for_cause<E>(cause: Cause<E>) -> ExitCode {
+  ExitCode::from(cause_max_exit_byte(&cause))
+}
+
+/// Map a synchronous [`Result`] from [`id_effect::runtime::run_blocking`] to an [`ExitCode`].
+///
+/// - `Ok(_)` → [`ExitCode::SUCCESS`]
+/// - `Err(_)` → `1` (typed channel; use [`exit_code_for_exit`] when you have a full [`Exit`])
+#[inline]
+pub fn exit_code_for_result<A, E>(result: Result<A, E>) -> ExitCode {
+  match result {
+    Ok(_) => ExitCode::SUCCESS,
+    Err(_) => ExitCode::from(1u8),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use id_effect::FiberId;
+  use rstest::rstest;
+
+  mod cause_max_exit_byte {
+    use super::*;
+
+    #[test]
+    fn fail_maps_to_one() {
+      assert_eq!(cause_max_exit_byte(&Cause::<&str>::fail("x")), 1);
+    }
+
+    #[test]
+    fn die_maps_to_101() {
+      assert_eq!(cause_max_exit_byte(&Cause::<&str>::die("boom")), 101);
+    }
+
+    #[test]
+    fn interrupt_maps_to_one_thirty() {
+      assert_eq!(
+        cause_max_exit_byte(&Cause::<&str>::interrupt(FiberId::new(1))),
+        130
+      );
+    }
+
+    #[test]
+    fn both_takes_max_of_children() {
+      let c = Cause::both(Cause::<&str>::fail("a"), Cause::<&str>::die("b"));
+      assert_eq!(cause_max_exit_byte(&c), 101);
+    }
+
+    #[test]
+    fn then_takes_max_of_children() {
+      let c = Cause::then(
+        Cause::<&str>::fail("a"),
+        Cause::<&str>::interrupt(FiberId::new(9)),
+      );
+      assert_eq!(cause_max_exit_byte(&c), 130);
+    }
+
+    #[test]
+    fn nested_both_respects_deepest_severity() {
+      let inner = Cause::both(Cause::<&str>::fail("f"), Cause::<&str>::die("d"));
+      let c = Cause::then(Cause::<&str>::fail("first"), inner);
+      assert_eq!(cause_max_exit_byte(&c), 101);
+    }
+  }
+
+  mod exit_code_for_exit {
+    use super::*;
+    use id_effect::Exit;
+
+    #[test]
+    fn success_yields_success_exit_code() {
+      assert_eq!(
+        exit_code_for_exit(Exit::<(), &str>::succeed(())),
+        ExitCode::SUCCESS
+      );
+    }
+
+    #[test]
+    fn failure_fail_yields_exit_code_one() {
+      let code = exit_code_for_exit(Exit::<(), &str>::fail("oops"));
+      assert_eq!(code, ExitCode::from(1u8));
+    }
+  }
+
+  mod exit_code_for_result {
+    use super::*;
+
+    #[rstest]
+    #[case::ok_ok(Ok::<u8, &str>(7), 0u8)]
+    #[case::err_maps_one(Err::<u8, &str>("e"), 1u8)]
+    fn maps_result_to_expected_byte(#[case] input: Result<u8, &str>, #[case] expected: u8) {
+      assert_eq!(exit_code_for_result(input), ExitCode::from(expected));
+    }
+  }
+}

--- a/crates/id_effect_cli/src/lib.rs
+++ b/crates/id_effect_cli/src/lib.rs
@@ -1,0 +1,24 @@
+//! CLI ergonomics for [`id_effect::Effect`] programs: **exit code mapping**, optional **[`clap`]**
+//! integration, and a small **`run_main`** helper.
+//!
+//! Design matches [Phase E — CLI ergonomics](https://github.com/Industrial/id_effect/blob/main/docs/effect-ts-parity/phases/phase-e-cli.md):
+//! embrace **`clap`** for parsing, run the effect with [`id_effect::runtime::run_blocking`], map
+//! [`Result`](std::result::Result) / [`id_effect::Exit`] / [`id_effect::Cause`] to
+//! [`std::process::ExitCode`] for `fn main() -> ExitCode`.
+//!
+//! [`clap`]: https://docs.rs/clap
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+mod exit_code;
+mod run;
+
+pub use exit_code::{
+  cause_max_exit_byte, exit_code_for_cause, exit_code_for_exit, exit_code_for_result,
+};
+pub use run::{RunMainConfig, run_main};
+
+#[cfg(feature = "clap")]
+#[doc(inline)]
+pub use clap;

--- a/crates/id_effect_cli/src/run.rs
+++ b/crates/id_effect_cli/src/run.rs
@@ -1,0 +1,87 @@
+//! `run_main` — tracing (optional), [`run_blocking`](id_effect::runtime::run_blocking), stderr, [`ExitCode`](std::process::ExitCode).
+
+use std::fmt::Debug;
+use std::process::ExitCode;
+
+use id_effect::{Effect, TracingConfig, install_tracing_layer, runtime::run_blocking};
+
+use crate::exit_code_for_result;
+
+/// Options for [`run_main`].
+#[derive(Clone, Debug)]
+pub struct RunMainConfig {
+  /// When `true`, installs the default tracing layer via [`install_tracing_layer`]
+  /// ([`TracingConfig::enabled`]) before running `effect`.
+  pub install_tracing: bool,
+}
+
+impl RunMainConfig {
+  /// No tracing install; only runs the effect and maps [`Result`] to [`ExitCode`].
+  #[inline]
+  pub fn minimal() -> Self {
+    Self {
+      install_tracing: false,
+    }
+  }
+
+  /// Same as [`RunMainConfig::minimal`] but installs tracing first.
+  #[inline]
+  pub fn with_tracing() -> Self {
+    Self {
+      install_tracing: true,
+    }
+  }
+}
+
+/// Run `effect` with `env`, optionally install tracing, log `Err` to **stderr**, return [`ExitCode`].
+///
+/// Typed failures (`Err(e)`) are printed with [`Debug`] (covers `E = ()` and structured errors).
+/// For user-facing CLI output, map errors to `String` (or implement a thin `Display` wrapper)
+/// before returning them from the effect.
+///
+/// For richer `Cause` handling (defect vs interrupt), use [`run_test`](id_effect::testing::run_test)
+/// or a custom driver, then [`exit_code_for_exit`](crate::exit_code_for_exit).
+#[inline]
+pub fn run_main<A, E, R>(effect: Effect<A, E, R>, env: R, config: RunMainConfig) -> ExitCode
+where
+  A: 'static,
+  E: 'static + Debug,
+  R: 'static,
+{
+  if config.install_tracing {
+    let _ = run_blocking(install_tracing_layer(TracingConfig::enabled()), ());
+  }
+  let result = run_blocking(effect, env);
+  if let Err(ref e) = result {
+    eprintln!("error: {e:?}");
+  }
+  exit_code_for_result(result)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use id_effect::{fail, succeed};
+
+  mod run_main {
+    use super::*;
+
+    #[test]
+    fn with_success_returns_success_exit_code() {
+      let code = run_main(succeed::<u8, (), ()>(9), (), RunMainConfig::minimal());
+      assert_eq!(code, ExitCode::SUCCESS);
+    }
+
+    #[test]
+    fn with_failure_returns_nonzero_exit_code() {
+      let code = run_main(fail::<u8, &str, ()>("boom"), (), RunMainConfig::minimal());
+      assert_eq!(code, ExitCode::from(1u8));
+    }
+
+    #[test]
+    fn with_tracing_flag_does_not_panic_on_success() {
+      let code = run_main(succeed::<(), (), ()>(()), (), RunMainConfig::with_tracing());
+      assert_eq!(code, ExitCode::SUCCESS);
+    }
+  }
+}

--- a/crates/id_effect_cli/tests/cli_probe_exit.rs
+++ b/crates/id_effect_cli/tests/cli_probe_exit.rs
@@ -1,0 +1,33 @@
+//! Integration tests: [`ie_cli_probe`](https://github.com/Industrial/id_effect/tree/main/crates/id_effect_cli) exit status.
+
+use std::process::Command;
+
+fn probe() -> Command {
+  Command::new(env!("CARGO_BIN_EXE_ie_cli_probe"))
+}
+
+mod ie_cli_probe_when_mode_ok {
+  use super::*;
+
+  #[test]
+  fn exits_with_success_status() {
+    let status = probe()
+      .args(["--mode", "ok"])
+      .status()
+      .expect("spawn ie_cli_probe");
+    assert!(status.success());
+  }
+}
+
+mod ie_cli_probe_when_mode_fail {
+  use super::*;
+
+  #[test]
+  fn exits_with_code_one() {
+    let status = probe()
+      .args(["--mode", "fail"])
+      .status()
+      .expect("spawn ie_cli_probe");
+    assert_eq!(status.code(), Some(1));
+  }
+}

--- a/examples/cli-minimal/Cargo.toml
+++ b/examples/cli-minimal/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "cli_minimal"
+version = "0.0.0"
+edition = "2024"
+publish = false
+description = "Phase E minimal CLI — clap + id_effect_cli + id_effect_config (Secret)"
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+# ConfigError is large; this example returns Result<_, ConfigError> like id_effect_config.
+result_large_err = "allow"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+clap = { version = "4.5", default-features = false, features = [
+  "std",
+  "derive",
+  "help",
+  "usage",
+  "error-context",
+] }
+id_effect = { path = "../../crates/id_effect", version = "0.2.0" }
+id_effect_cli = { path = "../../crates/id_effect_cli", version = "0.2.0", features = [
+  "clap",
+] }
+id_effect_config = { path = "../../crates/id_effect_config", version = "0.2.0" }

--- a/examples/cli-minimal/README.md
+++ b/examples/cli-minimal/README.md
@@ -1,0 +1,26 @@
+# Minimal CLI example (Phase E)
+
+Workspace package [`cli_minimal`](./Cargo.toml) mirrors the mdBook **CLI with clap** chapter:
+
+- Parse flags with [`clap`](https://docs.rs/clap).
+- Load [`Secret`](https://docs.rs/id_effect_config/latest/id_effect_config/struct.Secret.html) configuration via [`id_effect_config`](https://docs.rs/id_effect_config).
+- Finish with [`id_effect_cli::run_main`](https://docs.rs/id_effect_cli).
+
+## Build / run (from repo root)
+
+```bash
+devenv shell -- cargo build -p cli_minimal
+devenv shell -- cargo run -p cli_minimal -- --token demo
+```
+
+Or with Moon:
+
+```bash
+devenv shell -- moon run cli_minimal:build
+```
+
+## Tests
+
+```bash
+devenv shell -- cargo nextest run -p cli_minimal
+```

--- a/examples/cli-minimal/moon.yml
+++ b/examples/cli-minimal/moon.yml
@@ -1,0 +1,66 @@
+# https://moonrepo.dev/docs/config/project
+language: 'rust'
+layer: 'library'
+tasks:
+  check:
+    deps: ['effect:ci-format', '^:check']
+    command:
+      - cargo
+      - check
+      - -p
+      - cli_minimal
+      - --all-targets
+      - --all-features
+    inputs:
+      - 'Cargo.toml'
+      - 'src/**/*.rs'
+    options:
+      cache: true
+      outputStyle: buffer-only-failure
+  clippy:
+    deps: ['^:clippy', '~:check']
+    command:
+      - cargo
+      - clippy
+      - -p
+      - cli_minimal
+      - --all-targets
+      - --all-features
+      - --
+      - -D
+      - warnings
+    inputs:
+      - 'Cargo.toml'
+      - 'src/**/*.rs'
+    options:
+      cache: true
+      outputStyle: buffer-only-failure
+  test:
+    deps: ['^:test', '~:clippy']
+    command:
+      - cargo
+      - nextest
+      - run
+      - -p
+      - cli_minimal
+    inputs:
+      - 'Cargo.toml'
+      - 'src/**/*.rs'
+    options:
+      cache: true
+      outputStyle: buffer-only-failure
+  build:
+    deps: ['^:build', '~:test']
+    command:
+      - cargo
+      - build
+      - -p
+      - cli_minimal
+      - --all-targets
+      - --all-features
+    inputs:
+      - 'Cargo.toml'
+      - 'src/**/*.rs'
+    options:
+      cache: true
+      outputStyle: buffer-only-failure

--- a/examples/cli-minimal/src/lib.rs
+++ b/examples/cli-minimal/src/lib.rs
@@ -1,0 +1,56 @@
+//! Effect + config environment for the `cli_minimal` example (see mdBook CLI chapter).
+
+use id_effect::{Effect, run_blocking, succeed};
+use id_effect_config::{Config, ConfigEnv, ConfigError, MapConfigProvider, Secret, config_env};
+
+/// Build the program [`Effect`] and the matching [`ConfigEnv`] from a token string.
+///
+/// The token is injected as `API_TOKEN` for [`Config::string`] + [`.secret()`](Config::secret).
+pub fn app_effect(token: String) -> (Effect<(), ConfigError, ConfigEnv>, ConfigEnv) {
+  let provider = MapConfigProvider::from_pairs([("API_TOKEN", token.as_str())]);
+  let env = config_env(provider);
+  let load = Config::string("API_TOKEN")
+    .secret()
+    .run::<Secret<String>, ConfigError, ConfigEnv>();
+  let eff = load.flat_map(|_secret| succeed::<(), ConfigError, ConfigEnv>(()));
+  (eff, env)
+}
+
+/// Load secret synchronously (mirrors the mdBook “parse then `run_blocking`” snippet).
+pub fn load_token_secret(token: &str) -> Result<Secret<String>, ConfigError> {
+  let provider = MapConfigProvider::from_pairs([("API_TOKEN", token)]);
+  let env = config_env(provider);
+  run_blocking(
+    Config::string("API_TOKEN")
+      .secret()
+      .run::<Secret<String>, ConfigError, ConfigEnv>(),
+    env,
+  )
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use id_effect::{Exit, run_test};
+
+  mod app_effect {
+    use super::*;
+
+    #[test]
+    fn succeeds_when_token_matches_provider() {
+      let (eff, env) = app_effect("s3cr3t".into());
+      let exit = run_test(eff, env);
+      assert!(matches!(exit, Exit::Success(())));
+    }
+  }
+
+  mod load_token_secret {
+    use super::*;
+
+    #[test]
+    fn returns_secret_for_configured_key() {
+      let s = load_token_secret("abc").expect("load");
+      assert_eq!(*s.expose(), "abc");
+    }
+  }
+}

--- a/examples/cli-minimal/src/main.rs
+++ b/examples/cli-minimal/src/main.rs
@@ -1,0 +1,21 @@
+//! Minimal CLI: [`clap`] → [`cli_minimal::app_effect`] → [`id_effect_cli::run_main`].
+
+use clap::Parser;
+use id_effect_cli::{RunMainConfig, run_main};
+
+#[derive(Parser, Debug)]
+#[command(
+  name = "cli-minimal",
+  about = "Phase E example (see mdBook CLI chapter)"
+)]
+struct Cli {
+  /// API token (loaded into config as `API_TOKEN`, then wrapped as [`id_effect_config::Secret`]).
+  #[arg(long)]
+  token: String,
+}
+
+fn main() -> std::process::ExitCode {
+  let cli = Cli::parse();
+  let (eff, env) = cli_minimal::app_effect(cli.token);
+  run_main(eff, env, RunMainConfig::with_tracing())
+}


### PR DESCRIPTION
Implement @effect/cli-style process edge: clap-first parsing, run_main with optional tracing install, Exit/Cause/Result to ExitCode (Die maps to 101). Add workspace example cli_minimal (Secret + flat_map), ie_cli_probe integration tests, moon project wiring, book Part III CLI chapters and Exit doc fixes. Gates: format, check, clippy, test, book, coverage.