### PR TITLE
docs(book): add editorial style guide and pilot Part VI rewrites

### DIFF
--- a/crates/id_effect/book/STYLE.md
+++ b/crates/id_effect/book/STYLE.md
@@ -1,0 +1,138 @@
+# Typed Effects in Rust — Editorial Style Guide
+
+This document defines how the book is written. Every chapter should read like a **tutorial for a competent Rust async developer who is new to id_effect**, not like internal planning notes, crate READMEs, or ADR archives.
+
+## Reader
+
+**Assume:**
+
+- Comfortable with Rust: ownership, traits, `Result`, `async`/`await`, and `Future`.
+- Building or maintaining real async services (CLI tools, HTTP APIs, background workers).
+- No prior exposure to id_effect, Effect.ts, or category theory.
+
+**Do not assume:**
+
+- Knowledge of workspace layout, mission names, parity phases, or ADRs.
+- That the reader works on the id_effect repository.
+
+## Voice and tone
+
+| Do | Don't |
+|----|-------|
+| Explain **why** before **what** | Open with crate names or module tables |
+| Use second person ("you") sparingly and naturally | Write changelogs ("we added", "Phase G delivers") |
+| Name problems readers recognize (flaky retries, DI sprawl) | Reference `docs/effect-ts-parity/`, missions, or ADRs in body text |
+| State scope and limits honestly | Oversell experimental crates as production defaults |
+| Prefer plain language | Jargon without definition |
+
+**Banned in chapter prose** (fine in contributor-only docs):
+
+- `Mission: …`, `phase-*`, `ADR-*`, `tsk-*`, `pln-*`
+- Links to `docs/platform/ROADMAP.md` or parity phase folders as primary explanation
+- "This chapter documents…" — teach instead
+
+**Allowed once per book** where relevant: a short "For contributors" box in an appendix pointing to internal design docs.
+
+## Chapter anatomy
+
+Every chapter file uses this structure. Omit sections only when genuinely empty (e.g. no exercises in a one-page bridge).
+
+```markdown
+# Title — outcome-oriented, not crate name alone
+
+One paragraph: the **problem** this chapter solves and where it sits in the learning path.
+
+## What you'll learn
+
+- Bullet list of 3–5 concrete outcomes (skills, not API names).
+
+## Prerequisites
+
+- Links to prior chapters the reader should have read.
+
+## … teaching sections …
+
+Each section: concept → minimal example → slightly richer example → pitfall or "when not to use".
+
+## Putting it together
+
+Runnable or near-runnable program tying the chapter together (may continue a running example).
+
+## Summary
+
+Three to five sentences: what changed in the reader's mental model.
+
+## Next steps
+
+Links to the next chapter(s) in reading order.
+```
+
+### Section rules
+
+1. **Lead with motivation**, not API tables. Tables belong after the reader knows why the table exists.
+2. **One new idea per section.** If a section needs three H3s, consider splitting the file.
+3. **Examples must teach a story.** Prefer a single evolving domain (e.g. a small `orders` service) over disconnected `foo`/`bar` snippets.
+4. **Show the edge.** Every integration chapter ends with how to run, test, and swap implementations.
+5. **Link to `docs.rs` for exhaustive API**; the book teaches patterns, not every method.
+
+## Code examples
+
+- **Compile** unless explicitly marked `ignore` or `no_run` with a comment why.
+- **Complete enough to copy**: imports, `main` or test harness when the snippet is meant to run.
+- **Prefer workspace crates** as documented in `Cargo.toml`; pin narrative to stable public paths.
+- **Name types for clarity** over brevity (`OrderRepository`, not `Repo`).
+- After non-obvious blocks, add one sentence on what just happened.
+
+## Integration and platform chapters
+
+Chapters about workspace crates (`id_effect_axum`, `id_effect_host`, …) follow the **integration template**:
+
+1. **When you need this** — decision criteria vs alternatives (raw Tokio, raw Axum, other stacks).
+2. **Mental model** — how the crate sits on `Effect<A, E, R>` (one diagram or paragraph).
+3. **Minimal wiring** — smallest program that works.
+4. **Production concerns** — config, errors at the boundary, testing doubles.
+5. **Experimental / limits** — semver, single-process vs distributed, what to use instead at scale.
+
+Do **not** duplicate content across Part II (early wiring) and Part VI (platform depth). Part II teaches the **pattern once**; Part VI goes **deeper on operations** without re-listing every type.
+
+## Book structure conventions
+
+| Part | Role |
+|------|------|
+| I | Motivation + core `Effect` + `effect!` |
+| II | `R`, capabilities, providers, services — **one** full DI example |
+| III | Production mechanics: errors, fibers, resources, scheduling, CLI |
+| IV | Advanced topics on demand: STM, streams, schema, testing |
+| V | Optional functional patterns (optics, FSM, parsers, events) |
+| VI | Application platform: observability, data, host, messaging, workflow |
+| VII | Full-stack UI |
+| Appendices | Reference, migration, glossary, contributor tooling |
+
+**Reading order** in `SUMMARY.md` must match I → VII, then appendices.
+
+**Chapter IDs** (`chNN-`) are stable anchors; prefer new suffix files (`ch07-13-…`) over duplicate `ch07-12-*` names.
+
+## Cross-references
+
+- Link to **other book chapters** for concepts.
+- Link to **docs.rs** for API detail.
+- Link to **repository examples** with `cargo run -p … --example …` when a full sample exists.
+- Avoid linking to `docs/` tree in chapter body; fold essential context into prose.
+
+## Review checklist (per chapter)
+
+- [ ] Opens with a reader problem, not a crate name
+- [ ] "What you'll learn" present
+- [ ] No mission/phase/ADR references in prose
+- [ ] At least one runnable or `no_run`-justified example
+- [ ] Prerequisites and next steps linked
+- [ ] Summary restates mental model, not API list
+- [ ] `mdbook build` succeeds
+
+## Pilot and rollout
+
+1. Apply this guide to **Part I** (light edit — already closest to target).
+2. Normalize **Part VI** (furthest from target).
+3. Deduplicate **Part II ch07** integration sections vs Part VI.
+4. Mechanical pass on Parts III–V, VII.
+5. Appendices last (reference tone is acceptable).

--- a/crates/id_effect/book/src/SUMMARY.md
+++ b/crates/id_effect/book/src/SUMMARY.md
@@ -103,13 +103,6 @@
   - [Mocking Services](./part4/ch15-03-mocking.md)
   - [Property Testing](./part4/ch15-04-property-testing.md)
 
-# Appendices
-
-- [API Quick Reference](./appendix-a-api-reference.md)
-- [Migrating from `async fn` to effects](./appendix-b-migration.md)
-- [Glossary](./appendix-c-glossary.md)
-- [Workspace tooling (macros and lints)](./appendix-d-workspace-tooling.md)
-
 # Part V: Functional Patterns
 
 - [Optics (`id_effect_optics`)](./part5/ch18-00-optics.md)
@@ -153,3 +146,11 @@
 # Part VII: Full-stack UI
 
 - [Dioxus SSR and realtime](./part7/ch33-00-ui-realtime.md)
+
+# Appendices
+
+- [API Quick Reference](./appendix-a-api-reference.md)
+- [Migrating from `async fn` to effects](./appendix-b-migration.md)
+- [Glossary](./appendix-c-glossary.md)
+- [Workspace tooling (macros and lints)](./appendix-d-workspace-tooling.md)
+

--- a/crates/id_effect/book/src/part6/ch30-00-application.md
+++ b/crates/id_effect/book/src/part6/ch30-00-application.md
@@ -1,34 +1,85 @@
-# Application host
+# Hosting a production HTTP service
 
-[`id_effect_host`](../../../id_effect_host) wraps lifecycle, config bootstrap, auth trait surfaces, and security middleware for Axum services.
+You have domain logic in `Effect<A, E, R>` and an Axum router from [Axum host](../part2/ch07-08-axum-host.md). The next gap is **process lifecycle**: reading bind address and shutdown timeouts from the environment, stopping cleanly on SIGTERM, and layering session and security middleware without scattering that code across `main`.
 
-## Lifecycle
+The `id_effect_host` crate wraps those concerns so your binary stays a thin composition root.
 
-[`HostBuilder`](https://docs.rs/id_effect_host/latest/id_effect_host/struct.HostBuilder.html) loads [`HostConfig`](https://docs.rs/id_effect_host/latest/id_effect_host/struct.HostConfig.html) from `HOST`, `PORT`, and `SHUTDOWN_TIMEOUT_SECS`, then runs your `serve` future until SIGINT/SIGTERM:
+## What you'll learn
 
-```rust
-use id_effect_host::{HostBuilder, HostError};
+- When to use `HostBuilder` instead of hand-rolled `axum::serve` + signal handling.
+- How host configuration maps to environment variables.
+- How to plug in session and OAuth traits (or the in-memory stubs for tests).
+- Which security middleware ships with the crate and where it belongs in the stack.
 
-HostBuilder::new()
-  .run_until_shutdown(|host| async move {
-    // bind axum::serve with host.config.bind_port
+## Prerequisites
+
+- [A Complete DI Example](../part2/ch07-04-complete-example.md) — wiring `Env` at the edge.
+- [Axum host](../part2/ch07-08-axum-host.md) — running effects inside handlers.
+
+## When you need a host crate
+
+| Situation | Approach |
+|-----------|----------|
+| Local prototype, single route | `#[tokio::main]` + `axum::serve` is enough |
+| Service with env-driven port, graceful shutdown, shared middleware | `id_effect_host::HostBuilder` |
+| You already own all of the above in a company framework | Keep your framework; borrow ideas from host config only |
+
+The host crate does **not** replace Axum routing or effect interpreters—it standardizes **how the process starts and stops**.
+
+## Configuration and lifecycle
+
+`HostBuilder` loads `HostConfig` from `HOST`, `PORT`, and `SHUTDOWN_TIMEOUT_SECS`, then runs your `serve` future until SIGINT or SIGTERM:
+
+```rust,no_run
+use id_effect_host::HostBuilder;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    HostBuilder::new()
+        .run_until_shutdown(|host| async move {
+            // bind with host.config.bind_addr() and axum::serve(...)
+            Ok(())
+        })
+        .await?;
     Ok(())
-  })
-  .await?;
+}
 ```
 
-## Sessions and OAuth
+Set `PORT=0` in tests if you need an ephemeral port; read `host.config` inside the closure to build your router.
 
-Trait-only v1 — bring your own store/IdP:
+## Sessions and authentication (trait boundaries)
 
-- [`SessionStore`](https://docs.rs/id_effect_host/latest/id_effect_host/trait.SessionStore.html) + [`MemorySessionStore`](https://docs.rs/id_effect_host/latest/id_effect_host/struct.MemorySessionStore.html)
-- [`OAuthClient`](https://docs.rs/id_effect_host/latest/id_effect_host/trait.OAuthClient.html) + [`MemoryOAuthClient`](https://docs.rs/id_effect_host/latest/id_effect_host/struct.MemoryOAuthClient.html)
+Version 1 is intentionally **bring-your-own-store**:
+
+- `SessionStore` — persist session IDs and payloads (production: Redis, SQL; tests: `MemorySessionStore`).
+- `OAuthClient` — authorization URL and token exchange (production: your IdP client; tests: `MemoryOAuthClient`).
+
+Domain handlers stay in `Effect`; the host only exposes hooks so middleware can read the same session type you configure at startup. Implement the traits on your infrastructure types and pass them into whatever builder API your binary uses alongside `HostBuilder`.
 
 ## Security middleware
 
-- [`csp_middleware`](https://docs.rs/id_effect_host/latest/id_effect_host/fn.csp_middleware.html) — Content-Security-Policy
-- [`csrf_middleware`](https://docs.rs/id_effect_host/latest/id_effect_host/fn.csrf_middleware.html) — double-submit token on mutating verbs
+Two helpers ship for common HTTP hardening:
 
-## See also
+- **`csp_middleware`** — sets a Content-Security-Policy header appropriate for API or HTML responses you control.
+- **`csrf_middleware`** — double-submit cookie pattern on mutating verbs (`POST`, `PUT`, `PATCH`, `DELETE`).
 
-- Mission: `platform-application`
+Apply them **outside** effect-driven handlers (Tower/Axum layer order), after routing and before business logic. They do not inspect `Effect` failures; map those inside handlers via [RPC boundaries](../part2/ch07-12-rpc-boundaries.md) or your error type.
+
+## Putting it together
+
+A typical production binary:
+
+1. Build `Env` with providers ([Part II](../part2/ch07-03-providing-services.md)).
+2. Create the Axum router with `id_effect_axum` helpers.
+3. Wrap `axum::serve` in `HostBuilder::run_until_shutdown`.
+4. Install CSP/CSRF layers on the router before serve.
+
+Run integration tests with `MemorySessionStore` and a short `SHUTDOWN_TIMEOUT_SECS` so shutdown paths are covered without a real IdP.
+
+## Summary
+
+`id_effect_host` answers **how the OS process behaves**, not how domain effects compose. Use it when configuration, signals, and cross-cutting HTTP security should live in one place; keep business rules in `Effect` and wire them through Axum as in earlier chapters.
+
+## Next steps
+
+- [Async messaging and jobs](./ch31-00-async-messaging.md) — background work and outbox patterns after your HTTP surface is up.

--- a/crates/id_effect/book/src/part6/ch31-00-async-messaging.md
+++ b/crates/id_effect/book/src/part6/ch31-00-async-messaging.md
@@ -1,28 +1,94 @@
-# Async messaging
+# Background jobs and reliable messaging
 
-[`id_effect_jobs`](../../../id_effect_jobs) and [`id_effect_events`](../../../id_effect_events) cover background work and durable event journals.
+HTTP handlers should stay fast. Work that can fail, retry, or run later—sending email, charging a card, fan-out notifications—belongs on a **background path** with clear delivery semantics.
 
-## Job runner and outbox
+This chapter introduces `id_effect_jobs` for in-process job queues and transactional outbox relay, and ties them to `id_effect_events` when you need a durable audit trail.
 
-- [`MemoryJobRunner`](https://docs.rs/id_effect_jobs/latest/id_effect_jobs/struct.MemoryJobRunner.html) + [`drain_jobs`](https://docs.rs/id_effect_jobs/latest/id_effect_jobs/fn.drain_jobs.html)
-- [`MemoryOutbox`](https://docs.rs/id_effect_jobs/latest/id_effect_jobs/struct.MemoryOutbox.html) + [`relay_outbox`](https://docs.rs/id_effect_jobs/latest/id_effect_jobs/fn.relay_outbox.html) — transactional outbox MVP
+## What you'll learn
+
+- How to enqueue work with `MemoryJobRunner` and drain it in tests or a worker loop.
+- The transactional outbox pattern and the crate's `MemoryOutbox` + `relay_outbox` MVP.
+- When the in-memory `KafkaBrokerStub` is appropriate versus a real broker.
+- How `SqlEventJournal` persists domain events for projections and replay.
+
+## Prerequisites
+
+- [Application host](./ch30-00-application.md) — where HTTP and process lifecycle live.
+- [Error handling](../part3/ch08-00-error-handling.md) — modeling failures in effectful job handlers.
+
+## Why not `spawn` from every handler?
+
+Fire-and-forget `tokio::spawn` loses **backpressure**, **retry policy**, and **at-least-once** guarantees. A job runner lets you:
+
+- Run the same handler in tests synchronously (`drain_jobs`).
+- Attach logging and metrics at one boundary.
+- Evolve toward outbox + broker without rewriting domain code.
+
+## In-process jobs
+
+`MemoryJobRunner` stores pending jobs; `drain_jobs` executes them on the current thread—ideal for unit tests and single-node prototypes:
+
+```rust,no_run
+use id_effect_jobs::{MemoryJobRunner, drain_jobs};
+
+let runner = MemoryJobRunner::new();
+// enqueue from an Effect step or handler...
+drain_jobs(&runner)?;
+```
+
+Model each job as an `Effect` that receives capabilities in `R` (database, HTTP client) so production uses the same code path with a different runner implementation later.
+
+## Transactional outbox
+
+When a database commit and a message publish must succeed together, write the message to an **outbox table** in the same transaction, then relay asynchronously:
+
+```rust,no_run
+use id_effect_jobs::{MemoryOutbox, relay_outbox};
+
+let outbox = MemoryOutbox::new();
+// application writes row + outbox entry atomically in your DB layer
+relay_outbox(&outbox, |topic, payload| {
+    // publish to broker
+    Ok(())
+})?;
+```
+
+`MemoryOutbox` documents the API; production swaps in SQL-backed storage and a real broker client.
 
 ## Kafka adapter stub
 
-[`KafkaBrokerStub`](https://docs.rs/id_effect_jobs/latest/id_effect_jobs/struct.KafkaBrokerStub.html) implements [`MessageBroker`](https://docs.rs/id_effect_jobs/latest/id_effect_jobs/trait.MessageBroker.html) with in-memory fan-out until `rdkafka` lands:
+`KafkaBrokerStub` implements `MessageBroker` with in-memory fan-out until you add `rdkafka`:
 
 ```rust
-use id_effect_jobs::{KafkaBrokerStub, MessageBroker};
 use id_effect::run_blocking;
+use id_effect_jobs::{KafkaBrokerStub, MessageBroker};
 
 let broker = KafkaBrokerStub::new("localhost:9092");
 run_blocking(broker.publish("orders.created", br"{}", ()), ())?;
 ```
 
+Use it to teach topic naming and payload contracts in CI without a cluster. Replace the stub when you need partitioning, consumer groups, or cross-service delivery guarantees.
+
 ## SQL event journal
 
-[`SqlEventJournal`](https://docs.rs/id_effect_events/latest/id_effect_events/struct.SqlEventJournal.html) hardens persistence with [`POSTGRES_JOURNAL_DDL`](https://docs.rs/id_effect_events/latest/id_effect_events/constant.POSTGRES_JOURNAL_DDL.html) and [`TestSqlJournalBackend`](https://docs.rs/id_effect_events/latest/id_effect_events/struct.TestSqlJournalBackend.html) for unit tests.
+`SqlEventJournal` persists append-only domain events. Apply `POSTGRES_JOURNAL_DDL` once, then append from effectful command handlers. Tests use `TestSqlJournalBackend` without PostgreSQL when you only need persistence semantics.
 
-## See also
+Pair journals with [Events and projections](../part5/ch23-00-events-and-projections.md) when building read models.
 
-- Mission: `platform-async-messaging`
+## Putting it together
+
+A minimal order flow:
+
+1. HTTP handler commits order + outbox row in one transaction.
+2. Background task calls `relay_outbox` to publish `orders.created`.
+3. A consumer job updates a read model or calls an external API, with retries via [Scheduling](../part3/ch11-00-scheduling.md).
+
+Start with `MemoryJobRunner` and `MemoryOutbox` in tests; promote to SQL + real broker when load and durability require it.
+
+## Summary
+
+Treat **jobs** as effect programs with a runner boundary, and **messaging** as either in-process stubs or outbox-backed delivery—not ad hoc spawns from handlers. The crates here are MVPs that encode the pattern; infrastructure choices stay yours.
+
+## Next steps
+
+- [Workflow and cluster](./ch32-00-workflow-cluster.md) — durable multi-step processes when jobs are not enough.

--- a/crates/id_effect/book/templates/chapter.md
+++ b/crates/id_effect/book/templates/chapter.md
@@ -1,0 +1,25 @@
+# Chapter title — what the reader can do afterward
+
+<!-- One paragraph: real-world problem + where this fits in the book. No crate dump. -->
+
+## What you'll learn
+
+-
+-
+-
+
+## Prerequisites
+
+- [Prior chapter](./path.md) — one-line why
+
+## Putting it together
+
+<!-- Runnable or near-runnable example; continue the book's running example when possible. -->
+
+## Summary
+
+<!-- 3–5 sentences: mental model shift, not API inventory. -->
+
+## Next steps
+
+- [Next chapter](./path.md) — one-line teaser


### PR DESCRIPTION
Define reader-first writing standards and a chapter template, fix TOC order so Parts V–VII precede appendices, and rewrite application host and async messaging chapters as tutorials instead of internal crate inventories.