### PR TITLE
fix(docs): resolve broken rustdoc intra-doc links

### DIFF
--- a/crates/id_effect_events/src/lib.rs
+++ b/crates/id_effect_events/src/lib.rs
@@ -4,7 +4,7 @@
 //! | Type / fn | Role |
 //! |-----------|------|
 //! | [`EventStore`], [`MemoryEventStore`], [`FileJournal`] | append/read event journals |
-//! | [`EsEntityEventStore`] (feature `es-entity`) | production PG journal via es-entity |
+//! | `EsEntityEventStore` (feature `es-entity`) | production PG journal via es-entity |
 //! | [`ProjectionRunner`] | multi-projection rebuild order via [`id_effect_graph`] |
 //! | [`EventEnvelope`] | versioned payload with wire bridging via [`id_effect::schema::Schema`] |
 //! | [`run_projection`] | fold streams or stores through a [`Projection`] |

--- a/crates/id_effect_sql_pg/src/lib.rs
+++ b/crates/id_effect_sql_pg/src/lib.rs
@@ -1,4 +1,4 @@
-//! **PostgreSQL driver** for [`id_effect_sql`] — sqlx [`PgPool`] and
+//! **PostgreSQL driver** for [`id_effect_sql`] — sqlx [`PgPool`](sqlx::PgPool) and
 //! [`PgSqlClient`] implementing [`SqlClient`](id_effect_sql::SqlClient).
 //!
 //! See ADR [`adr-sql-driver-choice.md`](../../docs/platform/adrs/adr-sql-driver-choice.md).


### PR DESCRIPTION
## Summary
Fixes the Docs & Pages workflow failure on `main` ([run 27853264268](https://github.com/Industrial/id_effect/actions/runs/27853264268)).

- `id_effect_events`: stop intra-doc linking feature-gated `EsEntityEventStore` (not in scope during default `cargo doc`)
- `id_effect_sql_pg`: link `PgPool` via `sqlx::PgPool` instead of unresolved intra-crate link

## Publish workflow (separate change needed)
The publish failure ([run 27853768760](https://github.com/Industrial/id_effect/actions/runs/27853768760)) is because tag `v0.3.0` was pushed while workspace crates are `3.0.0` / `id_effect_platform` `4.0.0`.

After merging this PR, on `main`:
1. Update `.github/workflows/publish.yml` verify step to allow platform `4.0.0` on core release `3.0.0` (patch ready locally)
2. Delete erroneous tag `v0.3.0` and push `v3.0.0` on commit `134edd6` (or later)

## Test plan
- [ ] `moon run :docs` with `RUSTDOCFLAGS=-D warnings` passes
- [ ] Docs & Pages workflow green on `main`

Made with [Cursor](https://cursor.com)