### PR TITLE
fix(ci): skip all-features on Windows matrix (rdkafka)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,14 @@ jobs:
         with:
           key: ${{ matrix.toolchain }}-${{ matrix.os }}
       - name: cargo test (workspace)
-        run: cargo test --workspace --all-features
+        shell: bash
+        run: |
+          # rdkafka (kafka feature) does not build on Windows — skip optional features there.
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            cargo test --workspace
+          else
+            cargo test --workspace --all-features
+          fi
   # ──────────────────────────────────────────────────────────────────────────
   # Minimal-versions lock resolution (workspace-wide)
   # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
rdkafka-sys cannot build on Windows runners; run default features only on windows-latest while keeping --all-features on Unix/macOS.