### PR TITLE
fix: repair crates.io publish packaging and dependency order

### DIFF
--- a/.github/scripts/publish-crate.sh
+++ b/.github/scripts/publish-crate.sh
@@ -21,11 +21,15 @@ if echo "$output" | grep -qiE 'already (uploaded|exists)'; then
     exit 0
 fi
 if echo "$output" | grep -qi 'required permissions'; then
-    echo "::warning::$pkg publish denied (403) — token may lack publish-new scope or crate allowlist entry"
-    exit 0
+    echo "::error::$pkg publish denied (403) — token lacks publish-new scope or crate allowlist entry"
+    exit 1
+fi
+if echo "$output" | grep -qi 'readme .* does not appear to exist'; then
+    echo "::error::$pkg missing readme declared in Cargo.toml"
+    exit 1
 fi
 if echo "$output" | grep -qi 'no matching package named'; then
-    echo "::warning::$pkg publish skipped — registry dependency not published yet"
-    exit 0
+    echo "::error::$pkg publish blocked — internal dependency not on crates.io yet (check publish level order)"
+    exit 1
 fi
 exit "$code"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,7 @@
 name: Publish to crates.io
 # Trigger: push a semver tag, e.g.  git tag v0.3.0 && git push --tags
 # The tag must match the version in every publishable workspace Cargo.toml.
-# Crates are published in strict dependency order so that crates.io index
-# updates before downstream crates try to resolve them.
+# Crates are published in strict dependency order (including optional path deps).
 on:
   push:
     tags:
@@ -79,10 +78,22 @@ jobs:
         env:
           NEXTEST_NO_TESTS: pass
         run: cargo nextest run --workspace
+  validate-packaging:
+    name: Validate crate packaging
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+      - name: Validate all crates can package for publish
+        run: ./scripts/validate-crate-packaging.sh
   publish-level-0:
     name: Publish level-0 (graph, macro, proc_macro)
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [validate-packaging]
     environment: crates-io
     steps:
       - uses: actions/checkout@v6
@@ -130,7 +141,7 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: .github/scripts/publish-crate.sh id_effect
   publish-level-2:
-    name: Publish level-2 (cli, events, jobs, ...)
+    name: Publish level-2 (cli, jobs, logger, ...)
     runs-on: ubuntu-latest
     needs: [publish-level-1]
     environment: crates-io
@@ -147,13 +158,6 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: .github/scripts/publish-crate.sh id_effect_cli
-      - name: Wait for crates.io index
-        run: sleep 20
-      - name: Publish id_effect_events
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          DRY_RUN: ${{ inputs.dry_run || 'false' }}
-        run: .github/scripts/publish-crate.sh id_effect_events
       - name: Wait for crates.io index
         run: sleep 20
       - name: Publish id_effect_jobs
@@ -210,15 +214,8 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: .github/scripts/publish-crate.sh id_effect_tokio
-      - name: Wait for crates.io index
-        run: sleep 20
-      - name: Publish id_effect_workflow
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          DRY_RUN: ${{ inputs.dry_run || 'false' }}
-        run: .github/scripts/publish-crate.sh id_effect_workflow
   publish-level-3:
-    name: Publish level-3 (config, fsm, sql_pg, ...)
+    name: Publish level-3 (config, sql_pg, tower)
     runs-on: ubuntu-latest
     needs: [publish-level-2]
     environment: crates-io
@@ -237,13 +234,6 @@ jobs:
         run: .github/scripts/publish-crate.sh id_effect_config
       - name: Wait for crates.io index
         run: sleep 20
-      - name: Publish id_effect_fsm
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          DRY_RUN: ${{ inputs.dry_run || 'false' }}
-        run: .github/scripts/publish-crate.sh id_effect_fsm
-      - name: Wait for crates.io index
-        run: sleep 20
       - name: Publish id_effect_sql_pg
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -257,7 +247,7 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: .github/scripts/publish-crate.sh id_effect_tower
   publish-level-4:
-    name: Publish level-4 (ai, axum, opentelemetry)
+    name: Publish level-4 (ai, axum, events, ...)
     runs-on: ubuntu-latest
     needs: [publish-level-3]
     environment: crates-io
@@ -283,13 +273,27 @@ jobs:
         run: .github/scripts/publish-crate.sh id_effect_axum
       - name: Wait for crates.io index
         run: sleep 20
+      - name: Publish id_effect_events
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: .github/scripts/publish-crate.sh id_effect_events
+      - name: Wait for crates.io index
+        run: sleep 20
       - name: Publish id_effect_opentelemetry
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: .github/scripts/publish-crate.sh id_effect_opentelemetry
+      - name: Wait for crates.io index
+        run: sleep 20
+      - name: Publish id_effect_workflow
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: .github/scripts/publish-crate.sh id_effect_workflow
   publish-level-5:
-    name: Publish level-5 (rpc)
+    name: Publish level-5 (fsm, rpc)
     runs-on: ubuntu-latest
     needs: [publish-level-4]
     environment: crates-io
@@ -301,6 +305,13 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Wait for crates.io index
         run: sleep 30
+      - name: Publish id_effect_fsm
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: .github/scripts/publish-crate.sh id_effect_fsm
+      - name: Wait for crates.io index
+        run: sleep 20
       - name: Publish id_effect_rpc
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/crates/id_effect_sql_pg/README.md
+++ b/crates/id_effect_sql_pg/README.md
@@ -1,0 +1,15 @@
+# `id_effect_sql_pg`
+
+PostgreSQL driver for [`id_effect_sql`](../id_effect_sql) — sqlx `PgPool` and `PgSqlClient` wired into the id_effect SQL client traits.
+
+## Features
+
+- `PgSqlClient` implementing the driver-agnostic `SqlClient` trait from `id_effect_sql`
+- Connection pooling via sqlx `PgPool`
+- Transaction support through `id_effect_sql::with_transaction`
+
+## Usage
+
+Add both `id_effect_sql` and this crate, then provide a `PgSqlClient` backed by a shared `PgPool` in your layer graph.
+
+See [`id_effect_sql`](../id_effect_sql) for trait documentation and [`docs/platform/adrs/adr-sql-driver-choice.md`](../../docs/platform/adrs/adr-sql-driver-choice.md) for driver selection rationale.

--- a/scripts/validate-crate-packaging.sh
+++ b/scripts/validate-crate-packaging.sh
@@ -11,39 +11,39 @@ export CARGO_HOME="$cargo_dir"
 
 mkdir -p "$CARGO_HOME"
 {
-  echo '[patch.crates-io]'
-  while IFS= read -r toml; do
-    crate=$(grep -m1 '^name = ' "$toml" | sed 's/^name = "\(.*\)"/\1/')
-    [[ "$crate" == "$skip" ]] && continue
-    dir=$(cd "$(dirname "$toml")" && pwd)
-    echo "$crate = { path = \"$dir\" }"
-  done < <(find crates -mindepth 2 -maxdepth 2 -name Cargo.toml | sort)
+    echo '[patch.crates-io]'
+    while IFS= read -r toml; do
+        crate=$(grep -m1 '^name = ' "$toml" | sed 's/^name = "\(.*\)"/\1/')
+        [[ "$crate" == "$skip" ]] && continue
+        dir=$(cd "$(dirname "$toml")" && pwd)
+        echo "$crate = { path = \"$dir\" }"
+    done < <(find crates -mindepth 2 -maxdepth 2 -name Cargo.toml | sort)
 } > "$CARGO_HOME/config.toml"
 
 failed=0
 
 while IFS= read -r toml; do
-  crate=$(grep -m1 '^name = ' "$toml" | sed 's/^name = "\(.*\)"/\1/')
-  [[ "$crate" == "$skip" ]] && continue
+    crate=$(grep -m1 '^name = ' "$toml" | sed 's/^name = "\(.*\)"/\1/')
+    [[ "$crate" == "$skip" ]] && continue
 
-  if readme=$(grep -m1 '^readme = ' "$toml" | sed 's/^readme = "\(.*\)"/\1/'); then
-    dir=$(dirname "$toml")
-    if [[ ! -f "$dir/$readme" ]]; then
-      echo "ERROR: $crate declares readme = \"$readme\" but $dir/$readme is missing"
-      failed=1
-      continue
+    if readme=$(grep -m1 '^readme = ' "$toml" | sed 's/^readme = "\(.*\)"/\1/'); then
+        dir=$(dirname "$toml")
+        if [[ ! -f "$dir/$readme" ]]; then
+            echo "ERROR: $crate declares readme = \"$readme\" but $dir/$readme is missing"
+            failed=1
+            continue
+        fi
     fi
-  fi
 
-  if ! cargo package --package "$crate" --no-verify --allow-dirty --quiet 2>/tmp/validate-pkg.err; then
-    echo "ERROR: cargo package failed for $crate"
-    sed 's/^/  /' /tmp/validate-pkg.err
-    failed=1
-  fi
+    if ! cargo package --package "$crate" --no-verify --allow-dirty --quiet 2>/tmp/validate-pkg.err; then
+        echo "ERROR: cargo package failed for $crate"
+        sed 's/^/  /' /tmp/validate-pkg.err
+        failed=1
+    fi
 done < <(find crates -mindepth 2 -maxdepth 2 -name Cargo.toml | sort)
 
 if [[ "$failed" -ne 0 ]]; then
-  exit 1
+    exit 1
 fi
 
 echo "All publishable crates pass packaging validation"

--- a/scripts/validate-crate-packaging.sh
+++ b/scripts/validate-crate-packaging.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+cd "$root"
+
+skip=id_effect_lint
+cargo_dir=$(mktemp -d)
+trap 'rm -rf "$cargo_dir"' EXIT
+export CARGO_HOME="$cargo_dir"
+
+mkdir -p "$CARGO_HOME"
+{
+  echo '[patch.crates-io]'
+  while IFS= read -r toml; do
+    crate=$(grep -m1 '^name = ' "$toml" | sed 's/^name = "\(.*\)"/\1/')
+    [[ "$crate" == "$skip" ]] && continue
+    dir=$(cd "$(dirname "$toml")" && pwd)
+    echo "$crate = { path = \"$dir\" }"
+  done < <(find crates -mindepth 2 -maxdepth 2 -name Cargo.toml | sort)
+} > "$CARGO_HOME/config.toml"
+
+failed=0
+
+while IFS= read -r toml; do
+  crate=$(grep -m1 '^name = ' "$toml" | sed 's/^name = "\(.*\)"/\1/')
+  [[ "$crate" == "$skip" ]] && continue
+
+  if readme=$(grep -m1 '^readme = ' "$toml" | sed 's/^readme = "\(.*\)"/\1/'); then
+    dir=$(dirname "$toml")
+    if [[ ! -f "$dir/$readme" ]]; then
+      echo "ERROR: $crate declares readme = \"$readme\" but $dir/$readme is missing"
+      failed=1
+      continue
+    fi
+  fi
+
+  if ! cargo package --package "$crate" --no-verify --allow-dirty --quiet 2>/tmp/validate-pkg.err; then
+    echo "ERROR: cargo package failed for $crate"
+    sed 's/^/  /' /tmp/validate-pkg.err
+    failed=1
+  fi
+done < <(find crates -mindepth 2 -maxdepth 2 -name Cargo.toml | sort)
+
+if [[ "$failed" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "All publishable crates pass packaging validation"


### PR DESCRIPTION
## Summary
- Adds missing `id_effect_sql_pg/README.md` (hard publish failure at level 3)
- Reorders publish levels: `sql_pg` before `workflow`/`events`, `fsm` after `workflow`
- Adds `scripts/validate-crate-packaging.sh` pre-publish step (readme + `cargo package` with patched internal deps)
- Hardens `publish-crate.sh` to fail on 403, missing readme, and dependency ordering errors instead of silently skipping

## Root cause
Publish level 3 failed because `id_effect_sql_pg` declared `readme = "README.md"` but the file was missing. `id_effect_workflow` and `id_effect_fsm` were ordered before their `id_effect_sql_pg` / `id_effect_workflow` dependencies, causing cascading skips.

## Test plan
- [ ] CI passes
- [ ] Re-run publish workflow for `v0.3.0` after merge (note: new crates still need token with `publish-new` scope on crates.io)

Made with [Cursor](https://cursor.com)