### PR TITLE
fix(id_effect_workflow): trim keywords to crates.io limit

### DIFF
--- a/crates/id_effect_workflow/Cargo.toml
+++ b/crates/id_effect_workflow/Cargo.toml
@@ -6,7 +6,7 @@ description = "Durable step log with SQLite (memory) or duroxide-pg (production)
 license = "CC-BY-SA-4.0"
 repository = "https://github.com/Industrial/id_effect"
 readme = "README.md"
-keywords = ["effect", "workflow", "durable", "sqlite", "saga", "duroxide"]
+keywords = ["effect", "workflow", "durable", "sqlite", "saga"]
 categories = ["database"]
 
 [lints.rust]


### PR DESCRIPTION
## Summary
- Remove `duroxide` from `id_effect_workflow` keywords (crates.io allows max 5)
- All other workspace crates already have ≤5 keywords

## Test plan
- [x] Verified keyword counts across all `Cargo.toml` files
- [ ] CI passes
- [ ] Re-run publish workflow for `id_effect_workflow` v0.3.0

Made with [Cursor](https://cursor.com)