### PR TITLE
fix(jobs): persist obix relay cursor via register_event_handler

### DIFF
--- a/crates/id_effect/book/src/part6/ch31-00-async-messaging.md
+++ b/crates/id_effect/book/src/part6/ch31-00-async-messaging.md
@@ -27,7 +27,7 @@ Enable: `id_effect_jobs` features `apalis` (+ `postgres`).
 
 ## Transactional outbox — obix
 
-[`ObixOutbox`](../../../id_effect_jobs/struct.ObixOutbox.html) persists [`OutboxRecord`](../../../id_effect_jobs/struct.OutboxRecord.html) rows through [obix](https://docs.rs/obix) on the shared pool. Relay is driven by obix's native [`register_event_handler`](https://docs.rs/obix/latest/obix/struct.Outbox.html#method.register_event_handler), which persists the per-consumer cursor in `job_executions.execution_state_json` — restarts resume from the last acknowledged `EventSequence`. `ObixOutbox` does not implement `OutboxTable` because obix's append-only log has no shared `published` flag.
+[`ObixOutbox`](../../../id_effect_jobs/struct.ObixOutbox.html) persists [`OutboxRecord`](../../../id_effect_jobs/struct.OutboxRecord.html) rows through [obix](https://docs.rs/obix) on the shared pool. Relay is driven by obix's [`register_event_handler`](https://docs.rs/obix/latest/obix/struct.Outbox.html#method.register_event_handler); the per-consumer cursor lives in `job_executions.execution_state_json`.
 
 For unit tests only: `memory` feature + [`MemoryOutbox`](../../../id_effect_jobs/struct.MemoryOutbox.html) + [`relay_outbox`](../../../id_effect_jobs/fn.relay_outbox.html).
 

--- a/crates/id_effect/book/src/part6/ch31-00-async-messaging.md
+++ b/crates/id_effect/book/src/part6/ch31-00-async-messaging.md
@@ -27,7 +27,7 @@ Enable: `id_effect_jobs` features `apalis` (+ `postgres`).
 
 ## Transactional outbox — obix
 
-[`ObixOutbox`](../../../id_effect_jobs/struct.ObixOutbox.html) persists [`OutboxRecord`](../../../id_effect_jobs/struct.OutboxRecord.html) rows through [obix](https://docs.rs/obix) on the shared pool. Relay progress uses a sequence cursor (obix has no `published` flag).
+[`ObixOutbox`](../../../id_effect_jobs/struct.ObixOutbox.html) persists [`OutboxRecord`](../../../id_effect_jobs/struct.OutboxRecord.html) rows through [obix](https://docs.rs/obix) on the shared pool. Relay is driven by obix's native [`register_event_handler`](https://docs.rs/obix/latest/obix/struct.Outbox.html#method.register_event_handler), which persists the per-consumer cursor in `job_executions.execution_state_json` — restarts resume from the last acknowledged `EventSequence`. `ObixOutbox` does not implement `OutboxTable` because obix's append-only log has no shared `published` flag.
 
 For unit tests only: `memory` feature + [`MemoryOutbox`](../../../id_effect_jobs/struct.MemoryOutbox.html) + [`relay_outbox`](../../../id_effect_jobs/fn.relay_outbox.html).
 

--- a/crates/id_effect_jobs/examples/020_events_workflow_e2e.rs
+++ b/crates/id_effect_jobs/examples/020_events_workflow_e2e.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     EsEntityEventStore, EsEntityPgBackend, EventStore, Projection, ProjectionNode,
     ProjectionRunner, apply_es_entity_journal_ddl,
   };
-  use id_effect_jobs::{ObixOutbox, OutboxTable};
+  use id_effect_jobs::ObixOutbox;
   use id_effect_sql_pg::{PgPoolConfig, pg_pool_from_config};
   use id_effect_workflow::{DuroxideStepJournal, StepJournal, bootstrap_duroxide_schema};
   use obix::MailboxConfig;

--- a/crates/id_effect_jobs/src/lib.rs
+++ b/crates/id_effect_jobs/src/lib.rs
@@ -4,7 +4,7 @@
 //! |---------|-------|
 //! | `memory` (default) | [`MemoryJobRunner`], [`MemoryOutbox`], [`MemoryBroker`] |
 //! | `apalis` | `ApalisJobQueue`, `JobQueue` |
-//! | `obix` | `ObixOutbox`, `ObixInbox` |
+//! | `obix` | `ObixOutbox` (relay via `register_event_handler`), `ObixInbox` |
 //! | `kafka` | `RdKafkaBroker` |
 
 #![forbid(unsafe_code)]

--- a/crates/id_effect_jobs/src/obix_outbox.rs
+++ b/crates/id_effect_jobs/src/obix_outbox.rs
@@ -1,13 +1,4 @@
 //! Transactional outbox backed by [obix](https://docs.rs/obix) on a shared [`PgPool`](sqlx::PgPool).
-//!
-//! `insert` persists a [`JobsOutboxEvent`] row through obix; the relay path is driven by
-//! obix's native [`Outbox::register_event_handler`], which persists the per-consumer cursor
-//! in `job_executions.execution_state_json`. Restarts resume from the last acknowledged
-//! [`obix::EventSequence`].
-//!
-//! `ObixOutbox` deliberately does not implement [`OutboxTable`]: `OutboxTable`'s
-//! `fetch_unpublished` / `mark_published` / `unpublished_count` presume a mutable
-//! `published` flag on rows, which obix does not model.
 
 use id_effect::Effect;
 use obix::{MailboxConfig, Outbox, OutboxEventHandler, OutboxEventJobConfig};
@@ -73,9 +64,7 @@ impl ObixOutbox {
     &self.pool
   }
 
-  /// Append an outbox row in its own transaction (obix `publish_persisted_in_op`).
-  ///
-  /// Inherent counterpart to [`OutboxTable::insert`]; same signature.
+  /// Append an outbox row in its own transaction.
   pub fn insert(&self, record: OutboxRecord) -> Effect<OutboxRecord, OutboxError, ()> {
     let inner = self.inner.clone();
     let stored = record.clone();
@@ -99,10 +88,6 @@ impl ObixOutbox {
   }
 
   /// Register an obix-native relay handler.
-  ///
-  /// obix persists the relay cursor in `job_executions.execution_state_json`, so restarts
-  /// resume from the last acknowledged [`obix::EventSequence`]. Each event invocation gets
-  /// a fresh [`es_entity::DbOp`] so downstream writes acknowledge the cursor atomically.
   pub async fn register_event_handler<H>(
     &self,
     jobs: &mut ::job::Jobs,

--- a/crates/id_effect_jobs/src/obix_outbox.rs
+++ b/crates/id_effect_jobs/src/obix_outbox.rs
@@ -1,19 +1,21 @@
 //! Transactional outbox backed by [obix](https://docs.rs/obix) on a shared [`PgPool`](sqlx::PgPool).
 //!
-//! Implements [`OutboxTable`] by persisting [`JobsOutboxEvent`] rows through obix and tracking
-//! relay progress with a monotonic sequence cursor (obix has no `published` flag).
-
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+//! `insert` persists a [`JobsOutboxEvent`] row through obix; the relay path is driven by
+//! obix's native [`Outbox::register_event_handler`], which persists the per-consumer cursor
+//! in `job_executions.execution_state_json`. Restarts resume from the last acknowledged
+//! [`obix::EventSequence`].
+//!
+//! `ObixOutbox` deliberately does not implement [`OutboxTable`]: `OutboxTable`'s
+//! `fetch_unpublished` / `mark_published` / `unpublished_count` presume a mutable
+//! `published` flag on rows, which obix does not model.
 
 use id_effect::Effect;
-use obix::{EventSequence, MailboxConfig, Outbox};
+use obix::{MailboxConfig, Outbox, OutboxEventHandler, OutboxEventJobConfig};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use sqlx::PgPool;
 
 use crate::error::OutboxError;
-use crate::outbox::{OutboxRecord, OutboxTable};
+use crate::outbox::OutboxRecord;
 
 /// Event payload stored in obix `persistent_outbox_events.payload`.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -40,17 +42,6 @@ impl JobsOutboxEvent {
       created_ms: record.created_ms,
     }
   }
-
-  fn into_record(self, published: bool) -> OutboxRecord {
-    OutboxRecord {
-      id: self.id,
-      aggregate_id: self.aggregate_id,
-      event_type: self.event_type,
-      payload: self.payload,
-      created_ms: self.created_ms,
-      published,
-    }
-  }
 }
 
 /// Production outbox using obix on PostgreSQL.
@@ -58,12 +49,10 @@ impl JobsOutboxEvent {
 pub struct ObixOutbox {
   inner: Outbox<JobsOutboxEvent>,
   pool: PgPool,
-  relay_cursor: Arc<Mutex<EventSequence>>,
-  last_fetched: Arc<Mutex<HashMap<String, EventSequence>>>,
 }
 
 impl ObixOutbox {
-  /// Initialize obix listeners and caches on `pool`.
+  /// Initialize the obix outbox on `pool`.
   pub async fn init(pool: &PgPool, config: MailboxConfig) -> Result<Self, OutboxError> {
     let inner = Outbox::<JobsOutboxEvent>::init(pool, config)
       .await
@@ -71,12 +60,10 @@ impl ObixOutbox {
     Ok(Self {
       inner,
       pool: pool.clone(),
-      relay_cursor: Arc::new(Mutex::new(EventSequence::BEGIN)),
-      last_fetched: Arc::new(Mutex::new(HashMap::new())),
     })
   }
 
-  /// Underlying obix outbox (register handlers, listen for NOTIFY, etc.).
+  /// Underlying obix outbox, for advanced listener wiring (`listen_persisted`, `listen_all`, ...).
   pub fn obix(&self) -> &Outbox<JobsOutboxEvent> {
     &self.inner
   }
@@ -85,10 +72,11 @@ impl ObixOutbox {
   pub fn pool(&self) -> &PgPool {
     &self.pool
   }
-}
 
-impl OutboxTable for ObixOutbox {
-  fn insert(&self, record: OutboxRecord) -> Effect<OutboxRecord, OutboxError, ()> {
+  /// Append an outbox row in its own transaction (obix `publish_persisted_in_op`).
+  ///
+  /// Inherent counterpart to [`OutboxTable::insert`]; same signature.
+  pub fn insert(&self, record: OutboxRecord) -> Effect<OutboxRecord, OutboxError, ()> {
     let inner = self.inner.clone();
     let stored = record.clone();
     Effect::new_async(move |_r| {
@@ -110,85 +98,24 @@ impl OutboxTable for ObixOutbox {
     })
   }
 
-  fn fetch_unpublished(&self, limit: usize) -> Effect<Vec<OutboxRecord>, OutboxError, ()> {
-    let pool = self.pool.clone();
-    let relay_cursor = Arc::clone(&self.relay_cursor);
-    let last_fetched = Arc::clone(&self.last_fetched);
-    Effect::new_async(move |_r| {
-      Box::pin(async move {
-        let cursor = *relay_cursor
-          .lock()
-          .map_err(|e| OutboxError::Lock(e.to_string()))?;
-        let rows: Vec<(i64, Value)> = sqlx::query_as(
-          "SELECT sequence, payload FROM persistent_outbox_events            WHERE sequence > $1 ORDER BY sequence ASC LIMIT $2",
-        )
-        .bind(u64::from(cursor) as i64)
-        .bind(limit as i64)
-        .fetch_all(&pool)
-        .await
-        .map_err(|e| OutboxError::Storage(e.to_string()))?;
-        let mut out = Vec::with_capacity(rows.len());
-        let mut cache = last_fetched
-          .lock()
-          .map_err(|e| OutboxError::Lock(e.to_string()))?;
-        cache.clear();
-        for (sequence, payload) in rows {
-          let event: JobsOutboxEvent =
-            serde_json::from_value(payload).map_err(|e| OutboxError::Storage(e.to_string()))?;
-          cache.insert(event.id.clone(), EventSequence::from(sequence as u64));
-          out.push(event.into_record(false));
-        }
-        Ok(out)
-      })
-    })
-  }
-
-  fn mark_published(&self, ids: &[String]) -> Effect<(), OutboxError, ()> {
-    let ids: Vec<String> = ids.to_vec();
-    let relay_cursor = Arc::clone(&self.relay_cursor);
-    let last_fetched = Arc::clone(&self.last_fetched);
-    Effect::new_async(move |_r| {
-      Box::pin(async move {
-        let cache = last_fetched
-          .lock()
-          .map_err(|e| OutboxError::Lock(e.to_string()))?;
-        let mut cursor = relay_cursor
-          .lock()
-          .map_err(|e| OutboxError::Lock(e.to_string()))?;
-        let mut advanced = false;
-        for id in &ids {
-          let Some(sequence) = cache.get(id) else {
-            return Err(OutboxError::NotFound(id.clone()));
-          };
-          if u64::from(*sequence) > u64::from(*cursor) {
-            *cursor = *sequence;
-            advanced = true;
-          }
-        }
-        if !advanced && !ids.is_empty() {
-          // ids were present but cursor already past them — ok
-        }
-        Ok(())
-      })
-    })
-  }
-
-  fn unpublished_count(&self) -> Effect<usize, OutboxError, ()> {
-    let pool = self.pool.clone();
-    let relay_cursor = Arc::clone(&self.relay_cursor);
-    Effect::new_async(move |_r| {
-      Box::pin(async move {
-        let cursor = *relay_cursor
-          .lock()
-          .map_err(|e| OutboxError::Lock(e.to_string()))?;
-        let row: (i64,) =
-          sqlx::query_as("SELECT COUNT(*) FROM persistent_outbox_events WHERE sequence > $1")
-            .bind(u64::from(cursor) as i64)
-            .fetch_one(&pool)
-            .await
-            .map_err(|e| OutboxError::Storage(e.to_string()))?;
-        Ok(row.0.max(0) as usize)
-      })
-    })
+  /// Register an obix-native relay handler.
+  ///
+  /// obix persists the relay cursor in `job_executions.execution_state_json`, so restarts
+  /// resume from the last acknowledged [`obix::EventSequence`]. Each event invocation gets
+  /// a fresh [`es_entity::DbOp`] so downstream writes acknowledge the cursor atomically.
+  pub async fn register_event_handler<H>(
+    &self,
+    jobs: &mut ::job::Jobs,
+    config: OutboxEventJobConfig,
+    handler: H,
+  ) -> Result<(), OutboxError>
+  where
+    H: OutboxEventHandler<JobsOutboxEvent>,
+  {
+    self
+      .inner
+      .register_event_handler(jobs, config, handler)
+      .await
+      .map_err(|e| OutboxError::Storage(e.to_string()))
   }
 }

--- a/crates/id_effect_jobs/src/outbox.rs
+++ b/crates/id_effect_jobs/src/outbox.rs
@@ -53,6 +53,13 @@ impl OutboxRecord {
 }
 
 /// Transactional outbox persistence (append + mark-published).
+///
+/// Implemented by [`MemoryOutbox`] for tests and local demos. The obix-backed
+/// [`ObixOutbox`](crate::ObixOutbox) deliberately does **not** implement this trait:
+/// its relay path is driven by obix's native
+/// [`Outbox::register_event_handler`](obix::Outbox::register_event_handler),
+/// which persists the cursor in `job_executions.execution_state_json` rather than
+/// mutating a `published` flag on rows.
 pub trait OutboxTable: Send + Sync {
   /// Insert a row (typically in the same DB transaction as domain writes).
   fn insert(&self, record: OutboxRecord) -> Effect<OutboxRecord, OutboxError, ()>;

--- a/crates/id_effect_jobs/src/outbox.rs
+++ b/crates/id_effect_jobs/src/outbox.rs
@@ -53,13 +53,6 @@ impl OutboxRecord {
 }
 
 /// Transactional outbox persistence (append + mark-published).
-///
-/// Implemented by [`MemoryOutbox`] for tests and local demos. The obix-backed
-/// [`ObixOutbox`](crate::ObixOutbox) deliberately does **not** implement this trait:
-/// its relay path is driven by obix's native
-/// [`Outbox::register_event_handler`](obix::Outbox::register_event_handler),
-/// which persists the cursor in `job_executions.execution_state_json` rather than
-/// mutating a `published` flag on rows.
 pub trait OutboxTable: Send + Sync {
   /// Insert a row (typically in the same DB transaction as domain writes).
   fn insert(&self, record: OutboxRecord) -> Effect<OutboxRecord, OutboxError, ()>;

--- a/crates/id_effect_jobs/tests/pg_integration.rs
+++ b/crates/id_effect_jobs/tests/pg_integration.rs
@@ -3,10 +3,9 @@
 #![cfg(all(feature = "apalis", feature = "obix"))]
 
 use id_effect::run_async;
-use id_effect_jobs::{
-  ApalisJobQueue, JobSpec, JobsOutboxEvent, ObixOutbox, OutboxRecord, OutboxTable,
-};
-use obix::MailboxConfig;
+use id_effect_jobs::{ApalisJobQueue, JobSpec, JobsOutboxEvent, ObixOutbox, OutboxRecord};
+use obix::prelude::es_entity;
+use obix::{MailboxConfig, OutboxEventHandler, OutboxEventJobConfig, out::PersistentOutboxEvent};
 use sqlx::PgPool;
 
 async fn maybe_pool() -> Option<PgPool> {
@@ -29,28 +28,49 @@ async fn apalis_enqueue_smoke() {
   assert_eq!(record.spec.name, "smoke");
 }
 
+/// Handler used only to prove the native relay wiring compiles and registers.
+struct NoopHandler;
+
+impl OutboxEventHandler<JobsOutboxEvent> for NoopHandler {
+  async fn handle_persistent(
+    &self,
+    _op: &mut es_entity::DbOp<'_>,
+    _event: &PersistentOutboxEvent<JobsOutboxEvent>,
+  ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    Ok(())
+  }
+}
+
 #[tokio::test]
-async fn obix_outbox_round_trip() {
+async fn obix_outbox_smoke() {
   let Some(pool) = maybe_pool().await else {
-    eprintln!("pg_integration: DATABASE_URL unset — skipping obix_outbox_round_trip");
+    eprintln!("pg_integration: DATABASE_URL unset — skipping obix_outbox_smoke");
     return;
   };
 
   let config = MailboxConfig::builder().build().expect("mailbox config");
   let outbox = ObixOutbox::init(&pool, config).await.expect("obix init");
+
   let row = OutboxRecord::new("agg-1", "SmokeEvent", br#"{"ok":true}"#);
   let stored = run_async(outbox.insert(row), ()).await.expect("insert");
   assert_eq!(stored.event_type, "SmokeEvent");
+  assert!(!stored.id.is_empty());
 
-  let batch = run_async(outbox.fetch_unpublished(10), ())
+  // Wiring smoke: registering an obix-native handler through the new API path.
+  // End-to-end drain coverage lives in obix's own `outbox_event_handler` tests.
+  let job_config = ::job::JobSvcConfig::builder()
+    .pool(pool.clone())
+    .build()
+    .expect("job svc config");
+  let mut jobs = ::job::Jobs::init(job_config).await.expect("jobs init");
+  outbox
+    .register_event_handler(
+      &mut jobs,
+      OutboxEventJobConfig::new(::job::JobType::new("id_effect_jobs_obix_smoke")),
+      NoopHandler,
+    )
     .await
-    .expect("fetch");
-  assert!(!batch.is_empty());
-
-  let ids: Vec<String> = batch.iter().map(|r| r.id.clone()).collect();
-  run_async(outbox.mark_published(&ids), ())
-    .await
-    .expect("mark published");
+    .expect("register handler");
 
   let _payload: JobsOutboxEvent = serde_json::from_value(serde_json::json!({
     "id": stored.id,

--- a/crates/id_effect_jobs/tests/pg_integration.rs
+++ b/crates/id_effect_jobs/tests/pg_integration.rs
@@ -28,7 +28,6 @@ async fn apalis_enqueue_smoke() {
   assert_eq!(record.spec.name, "smoke");
 }
 
-/// Handler used only to prove the native relay wiring compiles and registers.
 struct NoopHandler;
 
 impl OutboxEventHandler<JobsOutboxEvent> for NoopHandler {
@@ -56,8 +55,6 @@ async fn obix_outbox_smoke() {
   assert_eq!(stored.event_type, "SmokeEvent");
   assert!(!stored.id.is_empty());
 
-  // Wiring smoke: registering an obix-native handler through the new API path.
-  // End-to-end drain coverage lives in obix's own `outbox_event_handler` tests.
   let job_config = ::job::JobSvcConfig::builder()
     .pool(pool.clone())
     .build()


### PR DESCRIPTION
Hi @Industrial

just looking at your work that uses our obix, job, es-entity crates.

Had an LLM scan the code and found a small possibility of improvement by moving to the `OutboxEventHandler` in favor of the hand rolled `relay_cursor` + `last_fetched` construct.

Like the id_effect project as a whole - lmk if there is anything you identify from the library usage that could be improved.

This PR is not intended for actual merge - just highlighting an option.

------------------
From here generated by `Claude-code`:

POC of driving the obix outbox through its native `OutboxEventHandler` primitive instead of the in-memory `relay_cursor` + `last_fetched` HashMap. obix persists the per-consumer cursor in `job_executions.execution_state_json`, so restarts resume from the last acknowledged `EventSequence` — the current implementation resets to `EventSequence::BEGIN` on every boot and re-publishes the entire log.

`ObixOutbox` drops its `OutboxTable` impl (obix's append-only log can't honestly satisfy a shared `published` flag); `insert` stays inherent with the same signature, and a new `register_event_handler` method wraps obix's primitive:

```rust
struct MyHandler;
impl OutboxEventHandler<JobsOutboxEvent> for MyHandler {
  async fn handle_persistent(
    &self,
    _op: &mut es_entity::DbOp<'_>,
    event: &PersistentOutboxEvent<JobsOutboxEvent>,
  ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
    // handle event.payload; cursor is persisted by obix automatically
    Ok(())
  }
}

outbox
  .register_event_handler(
    &mut jobs,
    OutboxEventJobConfig::new(JobType::new("my-relay")),
    MyHandler,
  )
  .await?;
```
