### PR TITLE
fix(docs): qualify broken intra-doc links in axum and rpc

### DIFF
--- a/.github/scripts/publish-crate.sh
+++ b/.github/scripts/publish-crate.sh
@@ -28,8 +28,8 @@ if echo "$output" | grep -qi 'readme .* does not appear to exist'; then
     echo "::error::$pkg missing readme declared in Cargo.toml"
     exit 1
 fi
-if echo "$output" | grep -qi 'no matching package named'; then
-    echo "::error::$pkg publish blocked — internal dependency not on crates.io yet (check publish level order)"
+if echo "$output" | grep -qi 'no matching package named\|didn't match\|failed to select a version for the requirement'; then
+    echo "::error::$pkg publish blocked — dependency version not on crates.io yet (check publish level order / path-only dev-deps)"
     exit 1
 fi
 exit "$code"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,22 @@ jobs:
       - name: cargo check (minimal versions, stable)
         run: cargo +stable check --workspace --all-features
   # ──────────────────────────────────────────────────────────────────────────
+  # crates.io packaging / publish-order (same script as publish.yml)
+  # Catches path+version chicken-and-egg before a tag publish fails mid-wave.
+  # ──────────────────────────────────────────────────────────────────────────
+  validate-packaging:
+    name: Validate crate packaging
+    runs-on: ubuntu-latest
+    needs: [moon-ci]
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+      - name: Validate crate packaging
+        run: bash scripts/validate-crate-packaging.sh
+  # ──────────────────────────────────────────────────────────────────────────
   # Required status check gate
   # ──────────────────────────────────────────────────────────────────────────
   ci-pass:
@@ -173,6 +189,7 @@ jobs:
       - coverage
       - matrix
       - minimal-versions
+      - validate-packaging
     if: always()
     steps:
       - name: Check all required jobs passed

--- a/crates/id_effect/Cargo.toml
+++ b/crates/id_effect/Cargo.toml
@@ -50,10 +50,9 @@ proptest = { version = "1", optional = true }
 tokio = { version = "1.50.0", features = ["macros", "rt", "time", "sync"] }
 
 [dev-dependencies]
-id_effect_config = { path = "../id_effect_config", version = "0.4.0" }
-id_effect_jobs = { path = "../id_effect_jobs", version = "0.4.0", features = [
-  "memory",
-] }
+# Path-only workspace test deps: version pins would require later publish levels on crates.io.
+id_effect_config = { path = "../id_effect_config" }
+id_effect_jobs = { path = "../id_effect_jobs", features = ["memory"] }
 trybuild = "1"
 criterion = "0.8.2"
 pollster = "0.4"

--- a/crates/id_effect_ai/Cargo.toml
+++ b/crates/id_effect_ai/Cargo.toml
@@ -32,10 +32,8 @@ tokio = { version = "1.50.0", features = ["time"] }
 
 [dev-dependencies]
 tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread", "time"] }
-id_effect_tokio = { path = "../id_effect_tokio", version = "0.4.0" }
-id_effect_cli = { path = "../id_effect_cli", version = "0.4.0", features = [
-  "clap",
-] }
+id_effect_tokio = { path = "../id_effect_tokio" }
+id_effect_cli = { path = "../id_effect_cli", features = ["clap"] }
 wiremock = "0.6"
 clap = { version = "4", features = ["derive"] }
 

--- a/crates/id_effect_axum/src/server/bootstrap.rs
+++ b/crates/id_effect_axum/src/server/bootstrap.rs
@@ -55,7 +55,7 @@ impl HostConfig {
   }
 }
 
-/// Load [`HostConfig`] using the installed [`ConfigProvider`] capability.
+/// Load [`HostConfig`] using the installed [`id_effect_config::ConfigProvider`] capability.
 #[inline]
 pub fn load_host_config<R>() -> Effect<HostConfig, ConfigError, R>
 where

--- a/crates/id_effect_jobs/Cargo.toml
+++ b/crates/id_effect_jobs/Cargo.toml
@@ -51,16 +51,15 @@ rdkafka = { version = "0.39", optional = true, default-features = false, feature
 ] }
 
 [dev-dependencies]
-id_effect_events = { path = "../id_effect_events", version = "0.4.0", features = [
-  "es-entity",
-] }
-id_effect_workflow = { path = "../id_effect_workflow", version = "0.4.0", default-features = false, features = [
+# Path-only: these crates publish after id_effect_jobs (or later in the same level).
+id_effect_events = { path = "../id_effect_events", features = ["es-entity"] }
+id_effect_workflow = { path = "../id_effect_workflow", default-features = false, features = [
   "duroxide",
 ] }
 rstest = "0.26"
 tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread"] }
-id_effect_tokio = { path = "../id_effect_tokio", version = "0.4.0" }
-id_effect_sql_pg = { path = "../id_effect_sql_pg", version = "0.4.0" }
+id_effect_tokio = { path = "../id_effect_tokio" }
+id_effect_sql_pg = { path = "../id_effect_sql_pg" }
 
 [[test]]
 name = "integration"

--- a/crates/id_effect_opentelemetry/Cargo.toml
+++ b/crates/id_effect_opentelemetry/Cargo.toml
@@ -68,7 +68,7 @@ axum = { version = "0.8" }
 http = "1"
 
 [dev-dependencies]
-id_effect_tokio = { path = "../id_effect_tokio", version = "0.4.0" }
+id_effect_tokio = { path = "../id_effect_tokio" }
 tower = { version = "0.5", features = ["util"] }
 tokio = { version = "1.50.0", features = [
   "macros",

--- a/crates/id_effect_parse/Cargo.toml
+++ b/crates/id_effect_parse/Cargo.toml
@@ -19,4 +19,4 @@ id_effect = { path = "../id_effect", version = "0.4.0" }
 
 [dev-dependencies]
 rstest = "0.26"
-id_effect_proc_macro = { path = "../id_effect_proc_macro", version = "0.4.0" }
+id_effect_proc_macro = { path = "../id_effect_proc_macro" }

--- a/crates/id_effect_platform/Cargo.toml
+++ b/crates/id_effect_platform/Cargo.toml
@@ -36,7 +36,7 @@ tokio = { version = "1.50.0", features = [
 ] }
 
 [dev-dependencies]
-id_effect_tokio = { path = "../id_effect_tokio", version = "0.4.0" }
+id_effect_tokio = { path = "../id_effect_tokio" }
 rstest = "0.26"
 tempfile = "3"
 tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread"] }

--- a/crates/id_effect_proc_macro/Cargo.toml
+++ b/crates/id_effect_proc_macro/Cargo.toml
@@ -18,10 +18,10 @@ name = "id_effect_proc_macro"
 proc-macro = true
 
 [dev-dependencies]
-id_effect = { path = "../id_effect", version = "0.4.0", features = [
-  "schema-serde",
-] }
-id_effect_optics = { path = "../id_effect_optics", version = "0.4.0" }
+# Path-only: published before `id_effect` / `id_effect_optics` (publish level-0).
+# A version pin would require those crates on crates.io first — chicken-and-egg.
+id_effect = { path = "../id_effect", features = ["schema-serde"] }
+id_effect_optics = { path = "../id_effect_optics" }
 
 [dependencies]
 proc-macro2 = "1.0"

--- a/crates/id_effect_rpc/Cargo.toml
+++ b/crates/id_effect_rpc/Cargo.toml
@@ -30,8 +30,8 @@ tracing = "0.1"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-id_effect_opentelemetry = { path = "../id_effect_opentelemetry", version = "0.4.0" }
-id_effect_tokio = { path = "../id_effect_tokio", version = "0.4.0" }
+id_effect_opentelemetry = { path = "../id_effect_opentelemetry" }
+id_effect_tokio = { path = "../id_effect_tokio" }
 syn = { version = "2", features = ["full"] }
 http-body-util = "0.1"
 rstest = "0.26"

--- a/crates/id_effect_rpc/src/client.rs
+++ b/crates/id_effect_rpc/src/client.rs
@@ -59,7 +59,7 @@ impl RpcClientConfig {
   }
 }
 
-/// Typed RPC client using [`HttpClient`] ([`@effect/rpc`](https://effect-ts.github.io/effect/docs/rpc) `RpcClient` parity).
+/// Typed RPC client using [`id_effect_platform::http::HttpClient`] ([`@effect/rpc`](https://effect-ts.github.io/effect/docs/rpc) `RpcClient` parity).
 #[derive(Clone, Debug)]
 pub struct RpcClient {
   config: RpcClientConfig,

--- a/crates/id_effect_sql/Cargo.toml
+++ b/crates/id_effect_sql/Cargo.toml
@@ -18,11 +18,12 @@ id_effect = { path = "../id_effect", version = "0.4.0" }
 
 [dev-dependencies]
 axum = { version = "0.8" }
-id_effect_axum = { path = "../id_effect_axum", version = "0.4.0" }
+# Path-only: id_effect_axum publishes after id_effect_sql.
+id_effect_axum = { path = "../id_effect_axum" }
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 
-id_effect_tokio = { path = "../id_effect_tokio", version = "0.4.0" }
+id_effect_tokio = { path = "../id_effect_tokio" }
 tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread", "net"] }
 rstest = "0.26"
 

--- a/crates/id_effect_sql_pg/Cargo.toml
+++ b/crates/id_effect_sql_pg/Cargo.toml
@@ -24,5 +24,5 @@ sqlx = { version = "0.8", default-features = false, features = [
 tokio = { version = "1.50.0", features = ["rt", "sync"] }
 
 [dev-dependencies]
-id_effect_tokio = { path = "../id_effect_tokio", version = "0.4.0" }
+id_effect_tokio = { path = "../id_effect_tokio" }
 tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread"] }

--- a/moon.yml
+++ b/moon.yml
@@ -111,7 +111,8 @@ tasks:
     command: 'cargo'
     args: ['doc', '--no-deps', '--workspace']
     env:
-      RUSTDOCFLAGS: ''
+      # Match Docs & Pages (`RUSTDOCFLAGS: -D warnings`) so PR CI catches rustdoc failures.
+      RUSTDOCFLAGS: '-D warnings'
     inputs:
       - 'Cargo.toml'
       - 'Cargo.lock'
@@ -157,9 +158,9 @@ tasks:
       cache: false
       outputStyle: buffer-only-failure
   check-docs:
-    description: 'Build docs and run clippy with -D warnings (public API docs via rustc lints)'
+    description: 'Build docs with -D warnings (same bar as Docs & Pages)'
     command: 'bash'
-    args: ['-c', 'RUSTDOCFLAGS="" cargo doc --workspace --no-deps 2>&1 | tee log/docs-warnings.log | grep -E "(warning|error|Documenting|Finished)"']
+    args: ['-c', 'RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps 2>&1 | tee log/docs-warnings.log | grep -E "(warning|error|Documenting|Finished)"']
     inputs:
       - 'Cargo.toml'
       - 'Cargo.lock'

--- a/scripts/validate-crate-packaging.sh
+++ b/scripts/validate-crate-packaging.sh
@@ -1,10 +1,115 @@
 #!/usr/bin/env bash
+# Validate that workspace crates can be packaged for crates.io publish.
+#
+# Checks:
+# 1) Publish-order: path+version pins must not require crates published later
+#    (cross-level or later in the same publish.yml wave).
+# 2) Dev-deps: workspace path deps in [dev-dependencies] must be path-only.
+#    cargo publish still resolves version against crates.io for path+version.
+# 3) cargo package with temporary [patch.crates-io] (sibling crates resolve locally).
 set -euo pipefail
 
 root=$(cd "$(dirname "$0")/.." && pwd)
 cd "$root"
 
 skip=id_effect_lint
+
+# Publish levels from .github/workflows/publish.yml (lower = earlier).
+declare -A LEVEL=(
+    [id_effect_graph]=0
+    [id_effect_macro]=0
+    [id_effect_proc_macro]=0
+    [id_effect]=1
+    [id_effect_cli]=2
+    [id_effect_jobs]=2
+    [id_effect_logger]=2
+    [id_effect_optics]=2
+    [id_effect_parse]=2
+    [id_effect_platform]=2
+    [id_effect_resilience]=2
+    [id_effect_sql]=2
+    [id_effect_tokio]=2
+    [id_effect_config]=3
+    [id_effect_sql_pg]=3
+    [id_effect_tower]=3
+    [id_effect_ai]=4
+    [id_effect_axum]=4
+    [id_effect_events]=4
+    [id_effect_opentelemetry]=4
+    [id_effect_workflow]=4
+    [id_effect_fsm]=5
+    [id_effect_rpc]=5
+)
+
+# Same-wave publish order (must match .github/workflows/publish.yml step order).
+declare -a ORDER=(
+    id_effect_graph id_effect_macro id_effect_proc_macro
+    id_effect
+    id_effect_cli id_effect_jobs id_effect_logger id_effect_optics
+    id_effect_parse id_effect_platform id_effect_resilience id_effect_sql id_effect_tokio
+    id_effect_config id_effect_sql_pg id_effect_tower
+    id_effect_ai id_effect_axum id_effect_events id_effect_opentelemetry id_effect_workflow
+    id_effect_fsm id_effect_rpc
+)
+declare -A ORD_IDX=()
+for i in "${!ORDER[@]}"; do ORD_IDX["${ORDER[$i]}"]=$i; done
+
+failed=0
+
+in_dev_deps_section() {
+    local toml="$1" needle="$2"
+    awk -v needle="$needle" '
+    /^\[[^]]*\]/ { sec=$0 }
+    index($0, needle) {
+      print (sec ~ /^\[dev-dependencies\]/) ? "yes" : "no"
+      exit
+    }
+  ' "$toml"
+}
+
+# --- Check 1+2: publish-order + path-only dev-deps ---
+while IFS= read -r toml; do
+    crate=$(grep -m1 '^name = ' "$toml" | sed 's/^name = "\(.*\)"/\1/')
+    [[ "$crate" == "$skip" ]] && continue
+    from_level=${LEVEL[$crate]:-}
+    [[ -z "$from_level" ]] && continue
+    from_ord=${ORD_IDX[$crate]:-}
+
+    while IFS= read -r line; do
+        dep=$(echo "$line" | sed -n 's/^\([a-zA-Z0-9_]*\) *=.*path *=.*version.*/\1/p')
+        [[ -z "$dep" ]] && continue
+        to_level=${LEVEL[$dep]:-}
+        [[ -z "$to_level" ]] && continue
+
+        if [[ "$(in_dev_deps_section "$toml" "$line")" == "yes" ]]; then
+            echo "ERROR: $crate [dev-dependencies] pins $dep with path+version"
+            echo "  → cargo publish resolves the version on crates.io even for path deps."
+            echo "  → Use path-only: $dep = { path = \"../$dep\" }"
+            echo "  in $toml: $line"
+            failed=1
+            continue
+        fi
+
+        if (( to_level > from_level )); then
+            echo "ERROR: $crate (publish level $from_level) pins $dep version but $dep publishes at level $to_level"
+            echo "  → cargo publish will look for $dep on crates.io before it exists."
+            echo "  → For test-only deps use path without version; for runtime deps fix publish order."
+            echo "  in $toml: $line"
+            failed=1
+            continue
+        fi
+
+        to_ord=${ORD_IDX[$dep]:-}
+        if [[ -n "$from_ord" && -n "$to_ord" ]] && (( to_level == from_level && to_ord > from_ord )); then
+            echo "ERROR: $crate pins $dep version but $dep publishes later in the same level ($from_level)"
+            echo "  → Reorder publish.yml or use path-only if this is a test-only dependency."
+            echo "  in $toml: $line"
+            failed=1
+        fi
+    done < <(grep -E '^[a-zA-Z0-9_]+ = \{.*path = .*version =' "$toml" || true)
+done < <(find crates -mindepth 2 -maxdepth 2 -name Cargo.toml | sort)
+
+# --- Check 3: cargo package with local patch ---
 cargo_dir=$(mktemp -d)
 trap 'rm -rf "$cargo_dir"' EXIT
 export CARGO_HOME="$cargo_dir"
@@ -19,8 +124,6 @@ mkdir -p "$CARGO_HOME"
         echo "$crate = { path = \"$dir\" }"
     done < <(find crates -mindepth 2 -maxdepth 2 -name Cargo.toml | sort)
 } > "$CARGO_HOME/config.toml"
-
-failed=0
 
 while IFS= read -r toml; do
     crate=$(grep -m1 '^name = ' "$toml" | sed 's/^name = "\(.*\)"/\1/')


### PR DESCRIPTION
ConfigProvider and HttpClient are not in local scope for rustdoc; link via id_effect_config / id_effect_platform so -D warnings passes.